### PR TITLE
chore: enable beads + symlink plugin into WP dev install

### DIFF
--- a/.aidevops.json
+++ b/.aidevops.json
@@ -7,7 +7,7 @@
     "code_quality": true,
     "time_tracking": true,
     "database": false,
-    "beads": false,
+    "beads": true,
     "sops": false,
     "security": true
   },
@@ -20,7 +20,9 @@
     "enabled": false
   },
   "beads": {
-    "enabled": false
+    "enabled": true,
+    "sync_on_commit": false,
+    "auto_ready_check": true
   },
   "sops": {
     "enabled": false,

--- a/.distignore
+++ b/.distignore
@@ -22,3 +22,4 @@ todo
 .agents
 .aidevops.json
 .beads
+wp-cli.yml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 .vscode/
 .phpunit.result.cache
 /composer.lock
+
+# Local-only tooling state
+.beads/
+.agents/loop-state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,9 @@ The `/jobs/{id}/result` handler reads `$request->get_url_params()['id']` directl
 - No streaming (broker buffers full completion; SSE would require a loopback-path upgrade)
 - VLM (vision-language) models not yet supported — worker normalises content-parts arrays to plain strings
 - Inference speed on integrated GPUs is single-digit tokens/sec; fine for async tasks, slow for chat
+
+## Task Tracking
+
+- `TODO.md` at repo root is the source of truth for tasks (aidevops convention).
+- [Beads](https://github.com/steveyegge/beads) is enabled as a local dependency-graph view. Sync with `~/.aidevops/agents/scripts/beads-sync-helper.sh push`. The `.beads/` directory is local state only and is gitignored — `bd init` must be re-run after a fresh clone.
+- Do not use `bd` as the primary tracker or follow the `bd prime` / `bd dolt push` workflow. Beads is derived from `TODO.md`, not the other way round.

--- a/wp-cli.yml
+++ b/wp-cli.yml
@@ -1,0 +1,2 @@
+path: ../wordpress
+url: http://wordpress.local:8080


### PR DESCRIPTION
## Summary

Follow-up to #1. Enables beads now that `dolt 1.86.0` is installed locally, and wires the plugin into the shared WordPress dev install via symlink + `wp-cli.yml`.

## Beads

- **Re-enable `beads` in `.aidevops.json`** with `sync_on_commit: false` and `auto_ready_check: true`. `database` feature stays off — this is a stateless broker plugin with no schemas/migrations/seeds to track.
- **Canonical database name**: `bd init` auto-detects the database name from the current directory, so running it from a worktree (e.g. `chore/aidevops-init`) produced a polluted name like `ultimate_ai_connector_webllm_chore_aidevops_init`. Reinitialised from the main worktree path so the name is stable as `ultimate_ai_connector_webllm` (issue prefix `ultimate-ai-connector-webllm-<hash>`). This matters because each dev re-runs `bd init` after cloning — they need to land on the same canonical name.
- **`.beads/` is local-only** — added to `.gitignore` to match `ai-provider-for-any-compatible-endpoint` and `hook-profiler` (the only two repos in this org that use beads). Beads is a purely-local dependency graph view; each clone re-inits.
- **Override `bd`'s AGENTS.md injection**: `bd init` tried to append a "BEADS INTEGRATION" block telling agents to "use `bd` for ALL task tracking" and to run `bd dolt push` at session end. Both directly conflict with the aidevops convention where `TODO.md` is the source of truth and beads is derived via `beads-sync-helper.sh push`. Reverted the bd additions and replaced them with a single "Task Tracking" section that encodes the aidevops flow.
- **Verified end-to-end**: `bd create` → `bd list` → `bd show` → `bd ready` → `bd close` → `bd delete --force` all succeed against the dolt sql-server on port 36757. Cross-worktree visibility confirmed — issues created from one worktree are visible from the other via the shared git common dir.

## WordPress dev install

- **`wp-cli.yml`** (new) — `path: ../wordpress`, `url: http://wordpress.local:8080`. Matches the convention used by `ai-provider-for-anthropic-max`, `the-perfect-wp-cron`, etc. Lets `wp` CLI commands work from the repo root without `--path`.
- **Symlink** (not committed — dev-environment artefact):

    ```bash
    ln -s /home/dave/Git/ultimate-ai-connector-webllm \
      /home/dave/Git/wordpress/wp-content/plugins/ultimate-ai-connector-webllm
    ```

- **Verified**: `wp plugin list` shows the plugin; `wp plugin activate ultimate-ai-connector-webllm` succeeds against the local WordPress 7.0-RC2 install; `webllm_loopback_secret` was auto-generated on first activation as expected.
- **Exclude `wp-cli.yml` from the release archive** via `.distignore` — the `path: ../wordpress` reference is meaningless in a zip that ends up in `wp-content/plugins/`, and it leaks a path convention end users don't need.

## Changes

| File | Change |
|---|---|
| `.aidevops.json` | Flip `beads.enabled` + feature flag to `true`, drop `database` stub |
| `.gitignore` | Add `.beads/` and `.agents/loop-state/` |
| `.distignore` | Add `wp-cli.yml` |
| `AGENTS.md` | Add "Task Tracking" section explaining TODO.md-as-source-of-truth + beads-as-derived-view |
| `wp-cli.yml` | New — points at `../wordpress` shared dev install |

## Verification commands

```bash
# Beads is healthy
bd doctor   # ✓ 67 passed, 6 warnings (bd CLI version, no remote, untracked .beads/ — all expected)
bd list     # Issues visible from both main and chore worktrees

# WP-CLI sees the plugin
wp plugin list | rg webllm
# ultimate-ai-connector-webllm  active  none  1.0.1  off
```

## Follow-ups

- Optional: run `beads-sync-helper.sh push` once there are real tasks in `TODO.md` (the current file only has format-example tasks in code blocks, which the helper's parser picks up as real — worth a separate issue upstream in aidevops).
- Optional: upgrade `bd` CLI from 0.62.0 → 1.0.0 when the aidevops framework bumps its pinned version.

---
[aidevops.sh](https://aidevops.sh) v3.6.157 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 19m and 59,587 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled beads for interactive dependency graph visualization and project task integration.

* **Documentation**
  * Added task tracking documentation including beads usage, synchronization workflows, and primary task sources.

* **Chores**
  * Updated development configuration files and version control ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->