### PR TITLE
t012: Phase 8 — Docs, .distignore, readme updates (v1.1.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — Ultimate AI Connector for WebLLM
 
-WordPress plugin that registers a WebLLM provider with the bundled WordPress AI Client SDK. LLM inference runs entirely in the user's browser on WebGPU via `@mlc-ai/web-llm`. The WordPress site is a broker — a persistent admin worker tab acts as the GPU, and any logged-in device on the install can submit prompts that get served by that tab.
+WordPress plugin that registers a WebLLM provider with the bundled WordPress AI Client SDK. LLM inference runs entirely in the user's browser on WebGPU via `@mlc-ai/web-llm`. The WordPress site is a broker — a SharedWorker (Chrome 124+/Edge 124+) or a dedicated admin tab (fallback) acts as the GPU, and any logged-in device on the install can submit prompts that get served by that worker.
 
 No third-party API. No API keys. No per-token cost. Model weights live in the browser cache.
 
@@ -18,21 +18,28 @@ No third-party API. No API keys. No per-token cost. Model weights live in the br
 
 ```
 PHP AI Client SDK ──▶ WebLlmProvider / WebLlmModel
-                       │  createRequest() → POST /wp-json/webllm/v1/chat/completions
+                       │  POST /wp-json/webllm/v1/chat/completions
                        ▼
              REST broker (inc/rest-api.php)
-                       │ enqueue job
-                       │ long-poll wait for result (raw $wpdb + COMMIT per tick)
-                       ▼
-             Browser worker tab (Tools → WebLLM Worker)
-                       │ GET /jobs/next (long-poll)
-                       │ engine.chat.completions.create(...)
-                       │ POST /jobs/{id}/result
-                       ▼
-             REST broker returns OpenAI-shaped response → SDK
+                       │ enqueue job, long-poll
+                       │ (raw $wpdb + COMMIT per tick)
+           ┌───────────┴───────────┐
+           ▼                       ▼
+     SharedWorker              Dedicated tab
+     (Chrome 124+,             (fallback for older
+      every admin              browsers and manual
+      tab shares one)          override)
+           │                       │
+           │  Both run              │
+           │  @mlc-ai/web-llm       │
+           │  on WebGPU             │
+           ▼                       ▼
+       GPU inference → POST /jobs/{id}/result → broker → SDK
 ```
 
 The broker bypasses WordPress's option/transient memoization and MySQL's REPEATABLE READ isolation with raw `$wpdb` queries plus an explicit `COMMIT` between iterations — otherwise the long-poll loop would freeze on its first read.
+
+The SharedWorker is spawned by the floating widget injected into every wp-admin page. It persists as long as at least one wp-admin tab is open in the same browser profile. The dedicated-tab fallback (Tools → WebLLM Worker) is still available for browsers without SharedWorker + WebGPU support.
 
 ## Directory Structure
 
@@ -108,9 +115,9 @@ The `/jobs/{id}/result` handler reads `$request->get_url_params()['id']` directl
 
 ## Distribution
 
-`.distignore` controls what composer excludes from the release archive. Current excludes: `.git`, `.github`, `.gitignore`, `.distignore`, `.idea`, `.vscode`, `.phpunit.result.cache`, `.DS_Store`, `node_modules`, `src`, `tests`, `phpunit.xml.dist`, `phpcs.xml.dist`, `webpack.config.js`, `package.json`, `package-lock.json`, `composer.lock`, `TODO.md`.
+`.distignore` controls what composer excludes from the release archive. Current excludes: `.git`, `.github`, `.gitignore`, `.distignore`, `.idea`, `.vscode`, `.phpunit.result.cache`, `.DS_Store`, `node_modules`, `src`, `tests`, `phpunit.xml.dist`, `phpcs.xml.dist`, `webpack.config.js`, `package.json`, `package-lock.json`, `composer.lock`, `TODO.md`, `AGENTS.md`, `.agents/`, `.aidevops.json`, `todo/`, `.beads/`, `wp-cli.yml`.
 
-**Note**: `.agents/`, `.aidevops.json`, `todo/`, and `AGENTS.md` should also be excluded from distribution — see `.distignore`.
+The `composer.json → archive.exclude` list must be kept in sync with `.distignore`.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A WordPress 7.0+ plugin that adds a **WebLLM** provider to the bundled AI Client SDK. Inference runs **entirely in the user's browser** on WebGPU via [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm) — no API keys, no data leaving the device, no usage fees.
 
-A persistent admin tab acts as the GPU; the WordPress site brokers requests so any logged-in device on the install (a phone, a tablet, a second laptop) can send a prompt and have it served by the desktop GPU.
+A SharedWorker running in the browser acts as the GPU; the WordPress site brokers requests so any logged-in device on the install (a phone, a tablet, a second laptop) can send a prompt and have it served by the desktop GPU.
 
 ## Why
 
@@ -14,31 +14,55 @@ This is the right answer when:
 - You want WP-AI features (excerpt generation, alt text, agents) at zero per-token cost.
 - You have a workstation with a dedicated GPU sitting idle and want to put it to use.
 
+## Quick start
+
+1. Install and activate the plugin on WordPress 7.0+.
+2. Visit any wp-admin page. A small floating icon appears in the corner.
+3. The first time you click an AI feature (e.g. the excerpt generator in WordPress/ai), a start modal appears showing the recommended model for your hardware. Click **Start**.
+4. Wait for the model to download (once per browser — cached in IndexedDB after that).
+5. Done. Every AI feature in WordPress is now served by your browser's GPU.
+
+The model stays loaded as you navigate between admin pages and between posts. Closing the last wp-admin tab frees the GPU memory. Reopening wp-admin reloads the model from cache in a few seconds.
+
+### Browser support
+
+- **Chrome 124+, Edge 124+ (desktop)** — full SharedWorker runtime, zero-config
+- **Older Chromium / Firefox / Safari** — fall back to the classic "Tools → WebLLM Worker (Manual mode)" page
+
+### Cross-device usage
+
+Because the WordPress site brokers requests, any logged-in device on the install can use the desktop's GPU. Open WP admin on your phone, click Generate excerpt, and the request is served by the SharedWorker in your desktop Chrome tab.
+
 ## How it works
 
 ```
-   PHP AI SDK ──▶ WebLlmProvider / Model
-                    │  createRequest() → POST /wp-json/webllm/v1/chat/completions
-                    ▼
-           REST: /webllm/v1/chat/completions
-                    │ enqueue job
-                    │ long-poll wait for result
-                    ▼
-           Browser worker tab (Tools → WebLLM Worker)
-                    │ poll /jobs/next
-                    │ run engine.chat.completions.create(...)
-                    │ POST /jobs/{id}/result
-                    ▼
-           PHP returns OpenAI-shaped response → SDK
+PHP AI SDK ──▶ WebLlmProvider / WebLlmModel
+                │  POST /wp-json/webllm/v1/chat/completions
+                ▼
+      REST broker (inc/rest-api.php)
+                │ enqueue job, long-poll
+                │
+    ┌───────────┴───────────┐
+    ▼                       ▼
+SharedWorker            Dedicated tab
+(Chrome 124+,           (fallback for older
+ every admin            browsers and manual
+ tab shares one)        override)
+    │                       │
+    │  Both run              │
+    │  @mlc-ai/web-llm       │
+    │  on WebGPU             │
+    ▼                       ▼
+GPU inference → POST /jobs/{id}/result → broker → SDK
 ```
 
-The WordPress site is the broker. Any device on the install can submit a prompt; whichever browser tab is currently running the worker page handles the inference. This is what enables "phone uses my desktop's GPU".
+The WordPress site is the broker. Any device on the install can submit a prompt; the SharedWorker (or fallback dedicated tab) handles the inference. This is what enables "phone uses my desktop's GPU".
 
 ## Requirements
 
 - **WordPress 7.0+** (uses the bundled AI Client SDK).
 - **PHP 7.4+**.
-- A modern desktop browser with **WebGPU** enabled. Chrome / Edge / Vivaldi on a machine with a discrete or recent integrated GPU. On Linux you may need to enable `chrome://flags/#enable-unsafe-webgpu`, `#enable-vulkan`, and `#ignore-gpu-blocklist`.
+- A modern desktop browser with **WebGPU** enabled. Chrome 124+ / Edge 124+ for the zero-config SharedWorker runtime. On Linux you may need to enable `chrome://flags/#enable-unsafe-webgpu`, `#enable-vulkan`, and `#ignore-gpu-blocklist`.
 - A GPU with **at least ~4 GB of VRAM** for the smallest useful chat models. Bigger models want 8–16 GB. WebLLM will fall back to SwiftShader on machines without a real GPU but inference will be unusably slow.
 
 ## Install
@@ -57,18 +81,32 @@ Symlink or copy the directory into `wp-content/plugins/`, then network-activate 
 
 ## Use
 
-1. Open **Tools → WebLLM Worker** in a desktop Chrome/Edge tab.
-2. Pick a model (the dropdown is the live `prebuiltAppConfig.model_list` from the installed `@mlc-ai/web-llm` package, with VRAM hints; the default is auto-selected based on your GPU's reported `maxBufferSize`).
-3. Click **Load model & start serving** and wait for the weights to download (cached in IndexedDB; subsequent loads are instant).
-4. The card flips to **● Online** and starts polling the job queue.
-5. Visit **Settings → Connectors**, find **WebLLM (Browser GPU)**, click **Configure**, and tune:
-    - **Default Model** — what the SDK should pick when no model is specified.
-    - **Request Timeout** — how long PHP waits for a worker response (default 180 s).
-    - **Context Window** — overrides MLC's baked-in 4 K cap. Bump to 8192 / 16384 if your AI agent has a large system prompt or tool definitions. Each doubling roughly doubles KV cache VRAM.
-    - **Allow remote clients** — when on, any logged-in user on the install can submit jobs that get served by your worker tab. Off = admin only.
-6. Use any WP AI feature normally (block-editor excerpt generation, alt-text, AI agent, etc.). The provider shows up under "WebLLM (Browser GPU)" wherever model pickers are exposed.
+### Zero-config (Chrome 124+ / Edge 124+)
 
-Keep the worker tab open. Closing it makes the provider go offline within ~90 seconds.
+1. Activate the plugin. A floating icon appears in the corner of every wp-admin page.
+2. Click any AI feature. A start modal shows the recommended model for your hardware.
+3. Click **Start** and wait for the model to download (cached in IndexedDB; subsequent loads are instant).
+4. Done. The SharedWorker stays loaded as you navigate between admin pages.
+
+### Manual mode (fallback for older browsers)
+
+1. Open **Tools → WebLLM Worker (Manual mode)** in a desktop Chrome/Edge tab.
+2. Pick a model (the dropdown is the live `prebuiltAppConfig.model_list` from the installed `@mlc-ai/web-llm` package, with VRAM hints; the default is auto-selected based on your GPU's reported `maxBufferSize`).
+3. Click **Load model & start serving** and wait for the weights to download.
+4. The card flips to **● Online** and starts polling the job queue.
+5. Keep this tab open. Closing it makes the provider go offline within ~90 seconds.
+
+### Settings
+
+Visit **Settings → Connectors**, find **WebLLM (Browser GPU)**, click **Configure**, and tune:
+
+- **Runtime mode** — Auto (SharedWorker on supported browsers, dedicated tab otherwise), SharedWorker only, Dedicated tab only, or Disabled.
+- **Default Model** — what the SDK should pick when no model is specified.
+- **Request Timeout** — how long PHP waits for a worker response (default 180 s).
+- **Context Window** — overrides MLC's baked-in 4 K cap. Bump to 8192 / 16384 if your AI agent has a large system prompt or tool definitions. Each doubling roughly doubles KV cache VRAM.
+- **Allow remote clients** — when on, any logged-in user on the install can submit jobs that get served by your worker tab. Off = admin only.
+
+Use any WP AI feature normally (block-editor excerpt generation, alt-text, AI agent, etc.). The provider shows up under "WebLLM (Browser GPU)" wherever model pickers are exposed.
 
 ## What gets advertised to the AI SDK
 
@@ -81,11 +119,13 @@ Only the **currently-loaded** model. Even though WebLLM ships with ~140 prebuilt
 - **Public model catalog.** `GET /webllm/v1/models` is unauthenticated — it returns the live worker-reported list, which is just the public `@mlc-ai/web-llm` package metadata, not sensitive.
 - **Direct DB reads in the long-poll.** WordPress's `get_option`/`get_transient` memoize results in a per-request static array, *and* `$wpdb` reuses one connection per request with MySQL's REPEATABLE READ isolation. Either of those would freeze the long-poll loop on its first read. The broker bypasses both with raw `$wpdb` queries plus an explicit `COMMIT` between iterations to start a fresh snapshot each tick.
 - **URL-param parsing.** The `/jobs/{id}/result` callback reads `$request->get_url_params()['id']` directly instead of `$request->get_param('id')` — the WebLLM completion JSON body itself contains an `id` field that would otherwise shadow the URL pattern match.
+- **SharedWorker lifetime.** The SharedWorker is spawned by the floating widget injected into every wp-admin page. It persists as long as at least one wp-admin tab is open in the same browser profile. The dedicated-tab fallback (Tools → WebLLM Worker) is still available for browsers without SharedWorker + WebGPU support.
 
 ## Settings reference
 
 | Option key | Type | Default | Notes |
 |---|---|---|---|
+| `webllm_runtime_mode` | string | `'auto'` | `auto`, `shared-worker`, `dedicated-tab`, or `disabled` |
 | `webllm_default_model` | string | `''` | Model id from the live prebuilt list. Empty = auto-pick. |
 | `webllm_request_timeout` | int | `180` | Seconds PHP waits for the worker to return a result. |
 | `webllm_context_window` | int | `8192` | KV cache size in tokens. Override of MLC's 4 K default. |
@@ -108,9 +148,10 @@ All under `webllm/v1`:
 ## Limitations
 
 - **Speed.** WebLLM on integrated GPUs is single-digit tokens per second. Fine for asynchronous tasks (alt text, summaries) but feels slow for interactive chat. A discrete GPU is much faster.
-- **One worker tab at a time.** No load balancing. The most recently-active worker wins.
+- **One active worker at a time.** No load balancing. The most recently-active SharedWorker (or dedicated tab) wins.
 - **No streaming.** The broker buffers the full completion before returning. Token-by-token streaming would require an SSE upgrade to the loopback path.
 - **VLM (vision-language) models not yet supported.** The worker normalizes content-parts arrays down to plain strings.
+- **SharedWorker requires Chrome 124+ or Edge 124+.** Older browsers and Firefox/Safari fall back to the dedicated-tab mode automatically.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 			".git",
 			".github",
 			".gitignore",
+			".gitattributes",
 			".distignore",
 			".idea",
 			".vscode",
@@ -50,7 +51,13 @@
 			"package.json",
 			"package-lock.json",
 			"composer.lock",
-			"TODO.md"
+			"TODO.md",
+			"AGENTS.md",
+			".agents",
+			".aidevops.json",
+			"todo",
+			".beads",
+			"wp-cli.yml"
 		]
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, webllm, webgpu, llm, on-device
 Requires at least: 7.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.0.2
+Stable tag: 1.1.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,7 +14,7 @@ Run LLM inference entirely in the user's browser via WebGPU + WebLLM. Routes thr
 
 This plugin registers a `WebLLM (Browser GPU)` provider with the WordPress 7.0 AI Client. Inference runs **entirely in your browser** using [WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU — no API keys, no data leaving the device.
 
-A persistent admin tab (Tools → WebLLM Worker) loads the model and serves requests. Because the WordPress site itself acts as a broker, any logged-in device on the same install — phone, tablet, second laptop — can submit a request and have it served by your desktop GPU, provided the worker tab is open.
+In Chrome 124+ and Edge 124+, a SharedWorker loads the model automatically when you open any wp-admin page — no dedicated tab required. The model stays loaded as you navigate between admin pages. On older browsers, a dedicated Tools → WebLLM Worker tab acts as the fallback. Because the WordPress site itself acts as a broker, any logged-in device on the same install — phone, tablet, second laptop — can submit a request and have it served by your desktop GPU.
 
 = Requirements =
 * Modern browser with WebGPU (Chrome / Edge desktop strongly recommended).
@@ -22,6 +22,15 @@ A persistent admin tab (Tools → WebLLM Worker) loads the model and serves requ
 * WordPress 7.0+ (bundled AI Client SDK).
 
 == Changelog ==
+
+= 1.1.0 =
+* NEW: Zero-config SharedWorker runtime — the LLM survives page navigation and shows a small floating icon in the corner of admin pages. No more keeping a dedicated worker tab open.
+* NEW: Auto-detected recommended model based on hardware capabilities.
+* NEW: apiFetch middleware intercepts AI requests from WordPress/ai experiments and shows a friendly start modal when the model isn't loaded yet.
+* NEW: Settings panel for the runtime mode (auto / shared-worker / dedicated-tab / disabled).
+* NEW: Hooks into `wpai_preferred_text_models` filter so AI Experiments (WordPress/ai plugin) actually routes through WebLLM when configured.
+* FALLBACK: Older browsers without SharedWorker + WebGPU support automatically fall back to the existing Tools → WebLLM Worker (Manual mode) page.
+* REQUIRES: Chrome 124+ or Edge 124+ for the SharedWorker runtime. Older browsers use the fallback.
 
 = 1.0.2 =
 * Fix: re-assert our `registerConnector()` call across multiple ticks (microtask + 0/50/250/1000ms) so the WP core `registerDefaultConnectors()` auto-register can't clobber our custom card with the generic API-key UI. The two scripts can run in either order depending on import-graph resolution; this guarantees we end up last. Resolves the regression where the WebLLM connector card showed an "API Key" input field instead of the worker-status panel.

--- a/ultimate-ai-connector-webllm.php
+++ b/ultimate-ai-connector-webllm.php
@@ -4,7 +4,7 @@
  * Description: Registers an AI Client provider that runs LLM inference entirely in the user's browser via WebGPU + WebLLM. A persistent worker tab acts as the GPU; the WordPress site brokers requests so any logged-in device (phone, tablet, second laptop) can use it.
  * Requires at least: 7.0
  * Requires PHP: 7.4
- * Version: 1.0.2
+ * Version: 1.1.0
  * Author: Ultimate Multisite Community
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later


### PR DESCRIPTION
## Summary

- Updates all user-facing documentation to describe the new zero-config SharedWorker runtime as the primary path and the dedicated tab as the fallback.
- Bumps version to 1.1.0 (minor bump — significant user-facing feature addition).
- Syncs `composer.json` archive.exclude with `.distignore` to prevent dev files leaking into the release archive.

## Changes

### README.md
- Replaced the "Open Tools → WebLLM Worker" quick start with the new zero-config SharedWorker flow (5-step install).
- Added browser support table (Chrome 124+/Edge 124+ = SharedWorker; older = fallback).
- Added cross-device usage section.
- Updated architecture diagram to show SharedWorker primary path with dedicated-tab fallback.
- Added `webllm_runtime_mode` to settings reference table.
- Added SharedWorker lifetime note to architecture notes.
- Restructured "Use" section into "Zero-config" and "Manual mode" subsections.

### readme.txt
- Bumped `Stable tag` from 1.0.2 to 1.1.0.
- Updated description paragraph to mention SharedWorker.
- Added 1.1.0 changelog entry listing all new features, fallback behaviour, and browser requirements.

### ultimate-ai-connector-webllm.php
- Bumped `Version:` header from 1.0.2 to 1.1.0.

### AGENTS.md
- Updated intro paragraph to describe SharedWorker as primary runtime.
- Replaced architecture diagram with two-path diagram (SharedWorker + dedicated-tab fallback).
- Updated Distribution section to reflect current `.distignore` state (no more "Note:" about missing entries).

### composer.json
- Synced `archive.exclude` with `.distignore`: added `AGENTS.md`, `.agents`, `.aidevops.json`, `todo`, `.beads`, `wp-cli.yml`, `.gitattributes`.

## Runtime Testing

**Risk level:** Low — documentation and version header only. No PHP or JS logic changes.
**Verification:** `self-assessed` — diff is scoped to doc files and version strings.

## Acceptance criteria verification

- [x] All 6 files updated consistently (README.md, readme.txt, plugin header, AGENTS.md, .distignore already correct, composer.json synced).
- [x] Version is 1.1.0 in both `readme.txt` (Stable tag) and plugin header.
- [x] Diff is scoped to documentation files — no PHP or JS logic changes.
- [ ] `composer archive` + `unzip -l` leak check — requires local composer install; CI will verify.
- [ ] `composer test` and `npm run build` — CI will verify.

Resolves #12

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.221 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 4m and 9,770 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SharedWorker-based zero-config execution model for Chrome 124+/Edge 124+ with automatic fallback support for older browsers
  * Auto model selection based on hardware
  * New settings panel for controlling runtime mode
  * API request interception with modal for seamless integration

* **Documentation**
  * Updated architecture documentation and configuration guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->