### PR TITLE
Fix connector settings URL in admin bar

### DIFF
--- a/inc/widget-injector.php
+++ b/inc/widget-injector.php
@@ -186,7 +186,7 @@ function register_admin_bar_node( $bar ): void {
 			'parent' => 'webllm-status',
 			'id'     => 'webllm-status-settings',
 			'title'  => __( 'Connector settings', 'ultimate-ai-connector-webllm' ),
-			'href'   => admin_url( 'options-general.php?page=ultimate-ai-connector-webllm' ),
+			'href'   => admin_url( 'options-connectors.php?page=ultimate-ai-connector-webllm' ),
 		]
 	);
 }


### PR DESCRIPTION
## Summary

- Fix the admin bar "Connector settings" link to point to `options-connectors.php` instead of `options-general.php`, which is the correct parent page for the connector settings UI.

## Changes

- `inc/widget-injector.php:189` — `options-general.php` → `options-connectors.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the admin "Connector settings" submenu link to navigate to the dedicated connector settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->