### PR TITLE
feat: WebGPU troubleshooting diagnostics

### DIFF
--- a/src/connector.jsx
+++ b/src/connector.jsx
@@ -8,6 +8,7 @@ import {
 	__experimentalRegisterConnector as registerConnector,
 	__experimentalConnectorItem as ConnectorItem,
 } from '@wordpress/connectors';
+import { diagnoseWebGpu, hasIssues } from './webgpu-troubleshooter';
 
 const { createElement, useState, useEffect, useCallback } = wp.element;
 const {
@@ -61,25 +62,22 @@ function WebLlmConnectorCard( { label, description, logo } ) {
 	const [ workerOnline, setWorkerOnline ] = useState( false );
 	const [ hasShaderF16, setHasShaderF16 ] = useState( false );
 	const [ saveError, setSaveError ] = useState( null );
+	const [ gpuDiag, setGpuDiag ] = useState( null );
 
 	const sharedWorkerAvailable =
 		typeof SharedWorker !== 'undefined' &&
 		typeof navigator !== 'undefined' &&
 		'gpu' in navigator;
 
-	// Detect shader-f16 on mount so we can hide f16 / BF16 models the
-	// local GPU cannot compile. The settings page may be open in a
-	// browser other than the one running the worker tab, so this is
-	// only a hint — but the admin bar widget will also filter
-	// independently at engine-load time.
+	// Detect shader-f16 and run WebGPU diagnostics on mount so we can
+	// hide f16 / BF16 models the local GPU cannot compile and surface
+	// troubleshooting guidance when problems are detected.
 	useEffect( () => {
 		( async () => {
 			try {
-				if ( ! navigator.gpu ) return;
-				const adapter = await navigator.gpu.requestAdapter();
-				if ( adapter?.features?.has?.( 'shader-f16' ) ) {
-					setHasShaderF16( true );
-				}
+				const diag = await diagnoseWebGpu();
+				setGpuDiag( diag );
+				setHasShaderF16( diag.hasShaderF16 );
 			} catch ( e ) {}
 		} )();
 	}, [] );
@@ -213,6 +211,28 @@ function WebLlmConnectorCard( { label, description, logo } ) {
 					'ultimate-ai-connector-webllm'
 				) }
 			</div>
+
+			{ hasIssues( gpuDiag ) && (
+				<div style={ { background: '#fef0f0', borderLeft: '4px solid #cc1818', padding: '10px 14px', fontSize: 13 } }>
+					<strong>{ __( 'WebGPU issue detected on this browser:', 'ultimate-ai-connector-webllm' ) }</strong>
+					{ gpuDiag.issues.map( ( issue, idx ) => (
+						<div key={ idx } style={ { marginTop: 6 } }>
+							<strong style={ { color: issue.severity === 'error' ? '#cc1818' : '#996800' } }>{ issue.title }</strong>
+							<span> &mdash; { issue.description }</span>
+							{ issue.steps && (
+								<ol style={ { margin: '4px 0 0 0', paddingLeft: 20 } }>
+									{ issue.steps.map( ( step, si ) => (
+										<li key={ si } style={ { marginBottom: 2 } }>{ step.text }</li>
+									) ) }
+								</ol>
+							) }
+						</div>
+					) ) }
+					<p style={ { marginTop: 8, marginBottom: 0, fontSize: 12, color: '#666' } }>
+						{ __( 'Note: This only affects this browser. The worker tab can run in a different browser with full WebGPU support.', 'ultimate-ai-connector-webllm' ) }
+					</p>
+				</div>
+			) }
 
 			<VStack spacing={ 3 }>
 				<SelectControl

--- a/src/floating-widget.jsx
+++ b/src/floating-widget.jsx
@@ -36,6 +36,7 @@
  */
 
 import { FLOATING_WIDGET_CSS } from './floating-widget-styles';
+import { diagnoseWebGpu, diagnoseWebLlmError, hasIssues } from './webgpu-troubleshooter';
 
 const {
 	createElement: h,
@@ -205,7 +206,13 @@ function createSharedWorkerClient() {
  * @return {Promise<{modelId: string|null, gpuName: string, vramHintGb: number}>}
  */
 async function detectHardware() {
-	const result = { modelId: null, gpuName: 'Unknown', vramHintGb: 0 };
+	const result = { modelId: null, gpuName: 'Unknown', vramHintGb: 0, gpuDiag: null };
+
+	// Run WebGPU diagnostics.
+	try {
+		result.gpuDiag = await diagnoseWebGpu();
+	} catch ( _ ) {}
+
 	if ( ! navigator.gpu ) {
 		return result;
 	}
@@ -408,6 +415,7 @@ function StartModal( {
 	hardware,
 	progress,
 	error,
+	gpuDiag,
 	onStart,
 	onCancel,
 	canStart,
@@ -531,15 +539,48 @@ function StartModal( {
 							progressText
 						)
 				),
-			error &&
-				h(
-					'div',
-					{ className: 'webllm-widget-error', role: 'alert' },
-					error
-				),
+		error &&
 			h(
 				'div',
-				{ className: 'webllm-widget-modal-actions' },
+				{ className: 'webllm-widget-error', role: 'alert' },
+				error
+			),
+		hasIssues( gpuDiag ) &&
+			h(
+				'details',
+				{
+					className: 'webllm-widget-troubleshooting',
+					open: gpuDiag && ( ! gpuDiag.adapterAvailable || ! gpuDiag.webgpuApiPresent ),
+					style: {
+						marginTop: 8,
+						padding: '8px 12px',
+						background: '#fff8e1',
+						borderLeft: '3px solid #f0b849',
+						borderRadius: 2,
+						fontSize: 12,
+						maxHeight: 200,
+						overflowY: 'auto',
+					},
+				},
+				h( 'summary', { style: { cursor: 'pointer', fontWeight: 600, fontSize: 13 } },
+					'Troubleshooting'
+				),
+				gpuDiag.issues.map( ( issue, idx ) =>
+					h( 'div', { key: idx, style: { marginTop: 6 } },
+						h( 'strong', { style: { color: issue.severity === 'error' ? '#cc1818' : '#996800' } },
+							issue.title
+						),
+						issue.steps && h( 'ol', { style: { margin: '4px 0 0 0', paddingLeft: 18, lineHeight: 1.5 } },
+							issue.steps.map( ( step, si ) =>
+								h( 'li', { key: si, style: { marginBottom: 2 } }, step.text )
+							)
+						)
+					)
+				)
+			),
+		h(
+			'div',
+			{ className: 'webllm-widget-modal-actions' },
 				h(
 					'button',
 					{
@@ -759,6 +800,7 @@ function WidgetRoot() {
 				hardware,
 				progress: state?.progress,
 				error: state?.error,
+				gpuDiag: hardware.gpuDiag || null,
 				onStart: handleStart,
 				onCancel: handleCancel,
 				canStart,

--- a/src/webgpu-troubleshooter.js
+++ b/src/webgpu-troubleshooter.js
@@ -1,0 +1,399 @@
+/**
+ * WebGPU troubleshooting diagnostics.
+ *
+ * Shared module that detects WebGPU problems and maps them to actionable
+ * remediation steps. Only surfaces guidance when a problem is detected --
+ * no noise for users where everything works.
+ *
+ * Consumed by: worker.jsx, floating-widget.jsx, widget-bootstrap.js,
+ * connector.jsx.
+ *
+ * @package UltimateAiConnectorWebLlm
+ */
+
+// ---------------------------------------------------------------------------
+// Detection: run a series of checks and return a diagnostic report.
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} WebGpuDiagnostic
+ * @property {boolean} webgpuApiPresent     - navigator.gpu exists
+ * @property {boolean} adapterAvailable     - requestAdapter() returned non-null
+ * @property {boolean} isSoftwareAdapter    - adapter reports software/CPU rendering
+ * @property {boolean} hasShaderF16         - shader-f16 extension available
+ * @property {boolean} isInsecureContext    - page served over HTTP (not localhost)
+ * @property {string|null} adapterDescription - human-readable adapter info
+ * @property {string|null} vendor           - GPU vendor string
+ * @property {Array<Object>} issues         - detected problems with remediation
+ */
+
+/**
+ * Probe WebGPU capabilities and return a diagnostic report.
+ *
+ * Safe to call in any context (main thread, SharedWorker). Returns issues
+ * only when problems are detected.
+ *
+ * @return {Promise<WebGpuDiagnostic>}
+ */
+export async function diagnoseWebGpu() {
+	const result = {
+		webgpuApiPresent: false,
+		adapterAvailable: false,
+		isSoftwareAdapter: false,
+		hasShaderF16: false,
+		isInsecureContext: false,
+		adapterDescription: null,
+		vendor: null,
+		issues: [],
+	};
+
+	// Check secure context (relevant for main thread only).
+	const nav = typeof navigator !== 'undefined' ? navigator : ( typeof self !== 'undefined' ? self.navigator : null );
+	if ( typeof window !== 'undefined' ) {
+		const isSecure = window.isSecureContext;
+		const isLocalhost = window.location?.hostname === 'localhost' ||
+			window.location?.hostname === '127.0.0.1' ||
+			window.location?.hostname === '::1';
+		if ( ! isSecure && ! isLocalhost ) {
+			result.isInsecureContext = true;
+		}
+	}
+
+	// Check navigator.gpu.
+	const gpu = nav?.gpu;
+	if ( ! gpu ) {
+		result.webgpuApiPresent = false;
+		result.issues.push( {
+			id: 'no-webgpu-api',
+			severity: 'error',
+			title: 'WebGPU API not available',
+			description: 'This browser does not expose the WebGPU API, which is required for in-browser AI inference.',
+			steps: buildNoWebGpuSteps( result.isInsecureContext ),
+		} );
+		return result;
+	}
+
+	result.webgpuApiPresent = true;
+
+	// Request adapter.
+	let adapter = null;
+	try {
+		adapter = await gpu.requestAdapter();
+	} catch ( e ) {
+		// requestAdapter threw -- treat as unavailable.
+	}
+
+	if ( ! adapter ) {
+		result.adapterAvailable = false;
+		result.issues.push( {
+			id: 'no-adapter',
+			severity: 'error',
+			title: 'No WebGPU adapter found',
+			description: 'The browser supports WebGPU but could not find a compatible GPU. This usually means the GPU is blocklisted or the Vulkan driver is not enabled.',
+			steps: buildNoAdapterSteps(),
+		} );
+		return result;
+	}
+
+	result.adapterAvailable = true;
+
+	// Read adapter info.
+	let info = {};
+	try {
+		if ( typeof adapter.requestAdapterInfo === 'function' ) {
+			info = await adapter.requestAdapterInfo();
+		} else if ( adapter.info ) {
+			info = adapter.info;
+		}
+	} catch ( e ) {}
+
+	result.vendor = info.vendor || null;
+	result.adapterDescription = [ info.vendor, info.architecture, info.device, info.description ]
+		.filter( Boolean ).join( ' / ' ) || null;
+
+	// Check for software rendering.
+	const descLower = ( result.adapterDescription || '' ).toLowerCase();
+	const isSoftware = descLower.includes( 'swiftshader' ) ||
+		descLower.includes( 'llvmpipe' ) ||
+		descLower.includes( 'software' ) ||
+		descLower.includes( 'cpu' ) ||
+		( info.adapterType === 'cpu' );
+	if ( isSoftware ) {
+		result.isSoftwareAdapter = true;
+		result.issues.push( {
+			id: 'software-rendering',
+			severity: 'warning',
+			title: 'Software rendering detected',
+			description: 'WebGPU is using a software renderer (' + ( result.adapterDescription || 'CPU' ) + ') instead of your GPU. Inference will be extremely slow. Your GPU may be blocklisted.',
+			steps: buildSoftwareRenderingSteps(),
+		} );
+	}
+
+	// Check shader-f16.
+	try {
+		if ( adapter.features && typeof adapter.features.has === 'function' ) {
+			result.hasShaderF16 = adapter.features.has( 'shader-f16' );
+		}
+	} catch ( e ) {}
+
+	// Insecure context warning (separate from the no-API case above,
+	// because WebGPU may still work on some browsers over HTTP but with
+	// degraded capabilities).
+	if ( result.isInsecureContext ) {
+		result.issues.push( {
+			id: 'insecure-context',
+			severity: 'warning',
+			title: 'Site served over HTTP',
+			description: 'This WordPress site is not using HTTPS. Some browsers restrict WebGPU features on insecure origins. If you experience issues, either enable HTTPS or add this origin to Chrome\'s insecure-origins allowlist.',
+			steps: buildInsecureContextSteps(),
+		} );
+	}
+
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Map web-llm error names to troubleshooting guidance.
+// ---------------------------------------------------------------------------
+
+/**
+ * Given an error from @mlc-ai/web-llm, return troubleshooting guidance
+ * or null if the error is not one we have specific advice for.
+ *
+ * @param {Error|string} error
+ * @return {Object|null} { id, severity, title, description, steps }
+ */
+export function diagnoseWebLlmError( error ) {
+	const name = error?.name || '';
+	const message = typeof error === 'string' ? error : ( error?.message || '' );
+
+	if ( name === 'WebGPUNotAvailableError' || name === 'WebGPUNotFoundError' ||
+		message.includes( 'WebGPU is not supported' ) || message.includes( 'Cannot find WebGPU' ) ) {
+		return {
+			id: 'webllm-no-webgpu',
+			severity: 'error',
+			title: 'WebGPU not available',
+			description: 'The AI engine requires WebGPU but it is not available in this browser.',
+			steps: buildNoWebGpuSteps( false ),
+		};
+	}
+
+	if ( name === 'ShaderF16SupportError' || message.includes( 'shader-f16' ) ) {
+		return {
+			id: 'webllm-no-f16',
+			severity: 'error',
+			title: 'shader-f16 extension not supported',
+			description: 'This model requires the shader-f16 WebGPU extension, which your GPU or browser does not support. Choose a model without "f16" or "BF16" in its name, or try enabling unsafe WebGPU APIs.',
+			steps: [
+				{
+					text: 'Choose a different model -- look for q4f32 variants instead of f16/BF16.',
+					type: 'action',
+				},
+				{
+					text: 'In Chrome/Edge, navigate to chrome://flags/#enable-unsafe-webgpu and set it to Enabled.',
+					type: 'chrome-flag',
+					flag: '#enable-unsafe-webgpu',
+				},
+			],
+		};
+	}
+
+	if ( name === 'DeviceLostError' || message.includes( 'device was lost' ) || message.includes( 'Device lost' ) ) {
+		return {
+			id: 'webllm-device-lost',
+			severity: 'error',
+			title: 'GPU device lost (out of memory)',
+			description: 'The GPU ran out of memory while loading the model. Try a smaller model or reduce the context window size in the connector settings.',
+			steps: [
+				{
+					text: 'Choose a smaller model (fewer parameters or lower quantization, e.g. 1B instead of 7B).',
+					type: 'action',
+				},
+				{
+					text: 'Reduce the "Context Window" setting in Settings > Connectors > WebLLM.',
+					type: 'action',
+				},
+				{
+					text: 'Close other GPU-intensive tabs or applications to free VRAM.',
+					type: 'action',
+				},
+			],
+		};
+	}
+
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Step builders -- each returns an array of remediation steps.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {boolean} isInsecureContext
+ * @return {Array<Object>}
+ */
+function buildNoWebGpuSteps( isInsecureContext ) {
+	const steps = [
+		{
+			text: 'Use a supported browser: Chrome 113+ or Edge 113+ on desktop. Safari and Firefox have limited or no WebGPU support.',
+			type: 'action',
+		},
+	];
+
+	if ( isInsecureContext ) {
+		steps.push( {
+			text: 'Your site is served over HTTP. WebGPU requires a secure context. Either set up HTTPS, or in Chrome/Edge go to chrome://flags/#unsafely-treat-insecure-origin-as-secure and add your site\'s URL (e.g. http://mysite.local).',
+			type: 'chrome-flag',
+			flag: '#unsafely-treat-insecure-origin-as-secure',
+		} );
+	}
+
+	steps.push(
+		{
+			text: 'In Chrome/Edge, navigate to chrome://flags/#enable-unsafe-webgpu and set it to Enabled, then relaunch.',
+			type: 'chrome-flag',
+			flag: '#enable-unsafe-webgpu',
+		},
+		{
+			text: 'Check chrome://gpu -- look for "WebGPU: Hardware accelerated". If it says "Disabled" or "Software only", continue with the steps below.',
+			type: 'diagnostic',
+		},
+		{
+			text: 'Enable chrome://flags/#ignore-gpu-blocklist to override GPU blocklist restrictions.',
+			type: 'chrome-flag',
+			flag: '#ignore-gpu-blocklist',
+		},
+		{
+			text: 'On Linux with NVIDIA or AMD GPUs, enable chrome://flags/#enable-vulkan to use the Vulkan backend. This is often required for WebGPU to detect your GPU.',
+			type: 'chrome-flag',
+			flag: '#enable-vulkan',
+		},
+		{
+			text: 'After changing flags, relaunch the browser completely (close all windows, not just the tab).',
+			type: 'action',
+		}
+	);
+
+	return steps;
+}
+
+/**
+ * @return {Array<Object>}
+ */
+function buildNoAdapterSteps() {
+	return [
+		{
+			text: 'Check chrome://gpu -- look for "WebGPU: Hardware accelerated". If it says "Disabled" or "Unavailable", your GPU may be blocklisted.',
+			type: 'diagnostic',
+		},
+		{
+			text: 'Enable chrome://flags/#ignore-gpu-blocklist to override browser GPU restrictions.',
+			type: 'chrome-flag',
+			flag: '#ignore-gpu-blocklist',
+		},
+		{
+			text: 'On Linux, enable chrome://flags/#enable-vulkan -- many GPUs (especially NVIDIA Pascal and older) need this for WebGPU.',
+			type: 'chrome-flag',
+			flag: '#enable-vulkan',
+		},
+		{
+			text: 'Enable chrome://flags/#enable-unsafe-webgpu for broader hardware support.',
+			type: 'chrome-flag',
+			flag: '#enable-unsafe-webgpu',
+		},
+		{
+			text: 'Ensure your GPU drivers are up to date. On Linux, check nvidia-smi or glxinfo.',
+			type: 'action',
+		},
+		{
+			text: 'After changing any flags, fully relaunch the browser.',
+			type: 'action',
+		},
+	];
+}
+
+/**
+ * @return {Array<Object>}
+ */
+function buildSoftwareRenderingSteps() {
+	return [
+		{
+			text: 'Check chrome://gpu for details on why your GPU is not being used.',
+			type: 'diagnostic',
+		},
+		{
+			text: 'Enable chrome://flags/#ignore-gpu-blocklist to force Chrome to use your GPU.',
+			type: 'chrome-flag',
+			flag: '#ignore-gpu-blocklist',
+		},
+		{
+			text: 'On Linux, enable chrome://flags/#enable-vulkan -- this is required for many GPUs.',
+			type: 'chrome-flag',
+			flag: '#enable-vulkan',
+		},
+		{
+			text: 'Ensure your GPU drivers are installed and up to date.',
+			type: 'action',
+		},
+		{
+			text: 'After changing flags, fully relaunch the browser.',
+			type: 'action',
+		},
+	];
+}
+
+/**
+ * @return {Array<Object>}
+ */
+function buildInsecureContextSteps() {
+	return [
+		{
+			text: 'Recommended: Set up HTTPS for your WordPress site (e.g. via a reverse proxy or local certificate).',
+			type: 'action',
+		},
+		{
+			text: 'Quick workaround: In Chrome/Edge, go to chrome://flags/#unsafely-treat-insecure-origin-as-secure and add your site URL (e.g. http://192.168.1.100).',
+			type: 'chrome-flag',
+			flag: '#unsafely-treat-insecure-origin-as-secure',
+		},
+		{
+			text: 'After changing the flag, relaunch the browser.',
+			type: 'action',
+		},
+	];
+}
+
+// ---------------------------------------------------------------------------
+// UI helper: format issues into a human-readable summary.
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true if the diagnostic has any issues worth showing.
+ *
+ * @param {WebGpuDiagnostic} diag
+ * @return {boolean}
+ */
+export function hasIssues( diag ) {
+	return diag && Array.isArray( diag.issues ) && diag.issues.length > 0;
+}
+
+/**
+ * Return a plain-text summary of all issues, suitable for console output
+ * or a simple text area. Used by widget-bootstrap.js where React is not
+ * available.
+ *
+ * @param {WebGpuDiagnostic} diag
+ * @return {string}
+ */
+export function formatIssuesPlainText( diag ) {
+	if ( ! hasIssues( diag ) ) {
+		return '';
+	}
+	return diag.issues.map( ( issue ) => {
+		let text = issue.title + ': ' + issue.description + '\n';
+		if ( issue.steps ) {
+			text += issue.steps.map( ( s, i ) => '  ' + ( i + 1 ) + '. ' + s.text ).join( '\n' );
+		}
+		return text;
+	} ).join( '\n\n' );
+}

--- a/src/widget-bootstrap.js
+++ b/src/widget-bootstrap.js
@@ -32,14 +32,39 @@
 	const hasSharedWorker = typeof SharedWorker !== 'undefined';
 	const hasWebGpu = typeof navigator !== 'undefined' && 'gpu' in navigator;
 
+	/**
+	 * Update the admin-bar node to show an unsupported state with a reason,
+	 * so users see feedback instead of a permanently-grey dot.
+	 *
+	 * @param {string} reason Short reason string.
+	 */
+	var showUnsupported = function ( reason ) {
+		var root = document.getElementById( 'wp-admin-bar-webllm-status' );
+		if ( ! root ) {
+			return;
+		}
+		var dot = root.querySelector( '.webllm-admin-bar-dot' );
+		if ( dot ) {
+			dot.setAttribute( 'data-state', 'error' );
+		}
+		var label = root.querySelector( '.webllm-admin-bar-label' );
+		if ( label ) {
+			label.textContent = reason;
+		}
+		// Add a title attribute so hover shows more detail.
+		root.title = reason + '. Use Tools \u2192 WebLLM Worker for dedicated-tab fallback, or check browser requirements in the WebGPU troubleshooting guide.';
+	};
+
 	if ( ! hasSharedWorker ) {
 		// eslint-disable-next-line no-console
-		console.debug( '[WebLLM] SharedWorker not supported; widget disabled. Use Tools → WebLLM Worker for dedicated-tab fallback.' );
+		console.debug( '[WebLLM] SharedWorker not supported; widget disabled. Use Tools \u2192 WebLLM Worker for dedicated-tab fallback.' );
+		showUnsupported( 'WebLLM: SharedWorker not supported' );
 		return;
 	}
 	if ( ! hasWebGpu ) {
 		// eslint-disable-next-line no-console
-		console.debug( '[WebLLM] WebGPU not supported; widget disabled.' );
+		console.debug( '[WebLLM] WebGPU not supported; widget disabled. Check chrome://flags for #enable-unsafe-webgpu, #enable-vulkan, #ignore-gpu-blocklist.' );
+		showUnsupported( 'WebLLM: WebGPU not available' );
 		return;
 	}
 

--- a/src/worker.jsx
+++ b/src/worker.jsx
@@ -16,6 +16,8 @@
  * @package UltimateAiConnectorWebLlm
  */
 
+import { diagnoseWebGpu, diagnoseWebLlmError, hasIssues } from './webgpu-troubleshooter';
+
 // Lazy module handle, populated by ensureWebLlmLoaded() on first use.
 let webllm = null;
 async function ensureWebLlmLoaded() {
@@ -203,25 +205,40 @@ function App() {
 	const [ adapterInfo, setAdapterInfo ] = useState( null );
 	const [ hasShaderF16, setHasShaderF16 ] = useState( false );
 	const [ error, setError ] = useState( null );
+	const [ gpuDiag, setGpuDiag ] = useState( null );
 	const stopRef = useRef( false );
 
 	// Probe WebGPU adapter info + shader-f16 support on mount. f16 models
 	// are hidden from the dropdown when the extension is missing — see
 	// t011 notes: the load would otherwise fail with
 	// "This model requires WebGPU extension shader-f16".
+	// Also runs the full diagnostics to surface troubleshooting guidance
+	// when problems are detected.
 	useEffect( () => {
 		( async () => {
 			try {
-				if ( ! navigator.gpu ) {
-					setError( __( 'This browser does not expose WebGPU. Use Chrome or Edge on desktop.', 'ultimate-ai-connector-webllm' ) );
+				const diag = await diagnoseWebGpu();
+				setGpuDiag( diag );
+				setHasShaderF16( diag.hasShaderF16 );
+
+				if ( ! diag.webgpuApiPresent ) {
+					setError( __( 'This browser does not expose WebGPU.', 'ultimate-ai-connector-webllm' ) );
 					return;
 				}
-				const adapter = await navigator.gpu.requestAdapter();
-				if ( adapter && adapter.info ) {
-					setAdapterInfo( adapter.info );
+				if ( ! diag.adapterAvailable ) {
+					setError( __( 'WebGPU is available but no GPU adapter was found. Your GPU may be blocklisted — see the troubleshooting steps below.', 'ultimate-ai-connector-webllm' ) );
+					return;
 				}
-				if ( adapter && adapter.features && typeof adapter.features.has === 'function' ) {
-					setHasShaderF16( adapter.features.has( 'shader-f16' ) );
+				if ( diag.isSoftwareAdapter ) {
+					setError( __( 'WebGPU is using software rendering instead of your GPU. Inference will be extremely slow — see the troubleshooting steps below.', 'ultimate-ai-connector-webllm' ) );
+				}
+
+				// Read adapter info for display.
+				if ( navigator.gpu ) {
+					const adapter = await navigator.gpu.requestAdapter();
+					if ( adapter && adapter.info ) {
+						setAdapterInfo( adapter.info );
+					}
 				}
 			} catch ( e ) {
 				// non-fatal
@@ -319,6 +336,14 @@ function App() {
 		} catch ( e ) {
 			setStatus( 'idle' );
 			setError( ( e && e.message ) || String( e ) );
+			// Check if the web-llm error has specific troubleshooting guidance.
+			const errorDiag = diagnoseWebLlmError( e );
+			if ( errorDiag ) {
+				setGpuDiag( ( prev ) => ( {
+					...( prev || {} ),
+					issues: [ errorDiag, ...( prev?.issues || [] ).filter( ( i ) => i.id !== errorDiag.id ) ],
+				} ) );
+			}
 		}
 	}, [ modelId ] );
 
@@ -470,6 +495,44 @@ function App() {
 		value: m.model_id || m.id,
 	} ) );
 
+	// Render a collapsible troubleshooting panel when issues are detected.
+	const troubleshootingPanel = hasIssues( gpuDiag ) && h( 'details', {
+		style: {
+			marginTop: 4,
+			padding: '10px 14px',
+			background: '#fff8e1',
+			borderLeft: '4px solid #f0b849',
+			borderRadius: 2,
+			fontSize: 13,
+		},
+		open: ! gpuDiag.adapterAvailable || ! gpuDiag.webgpuApiPresent,
+	},
+		h( 'summary', { style: { cursor: 'pointer', fontWeight: 600 } },
+			__( 'Troubleshooting: WebGPU setup', 'ultimate-ai-connector-webllm' )
+		),
+		gpuDiag.issues.map( ( issue, idx ) =>
+			h( 'div', { key: idx, style: { marginTop: 10 } },
+				h( 'strong', { style: { color: issue.severity === 'error' ? '#cc1818' : '#996800' } }, issue.title ),
+				h( 'p', { style: { margin: '4px 0' } }, issue.description ),
+				issue.steps && h( 'ol', { style: { margin: '6px 0 0 0', paddingLeft: 20 } },
+					issue.steps.map( ( step, si ) =>
+						h( 'li', {
+							key: si,
+							style: {
+								marginBottom: 4,
+								...(
+									step.type === 'chrome-flag'
+										? { fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12 }
+										: {}
+								),
+							},
+						}, step.text )
+					)
+				)
+			)
+		)
+	);
+
 	if ( libLoading ) {
 		return h( Card, null,
 			h( CardBody, null,
@@ -518,9 +581,11 @@ function App() {
 						: h( Spinner, null )
 				),
 
-				error && h( Notice, { status: 'error', isDismissible: false }, error ),
+			error && h( Notice, { status: 'error', isDismissible: false }, error ),
 
-				h( HStack, { justify: 'flex-start', spacing: 3 },
+			troubleshootingPanel,
+
+			h( HStack, { justify: 'flex-start', spacing: 3 },
 					status !== 'ready' && h( Button, {
 						variant: 'primary',
 						onClick: loadModel,


### PR DESCRIPTION
## Summary

- Adds contextual WebGPU troubleshooting guidance that only appears when a problem is detected -- zero UI noise when everything works.
- Surfaces actionable `chrome://flags` steps (`#enable-unsafe-webgpu`, `#enable-vulkan`, `#ignore-gpu-blocklist`, `#unsafely-treat-insecure-origin-as-secure`) based on the specific failure mode: no WebGPU API, null adapter (GPU blocklisted), software rendering, insecure HTTP origin, or web-llm named errors (`DeviceLostError`, `ShaderF16SupportError`).
- Fixes the silent failure in the admin-bar widget bootstrap -- the dot now turns red with a visible label instead of staying permanently grey with no explanation.

## Changes

### New: `src/webgpu-troubleshooter.js`
Shared diagnostic module with three exports:
- `diagnoseWebGpu()` -- probes the full stack (API presence, adapter availability, software rendering, insecure context, shader-f16)
- `diagnoseWebLlmError(error)` -- maps `@mlc-ai/web-llm` error types to specific remediation steps
- `hasIssues(diag)` -- guard so UI only renders troubleshooting when problems exist

### Modified entry points
| File | Change |
|---|---|
| `src/worker.jsx` | Handles adapter-null case (was unchecked), shows collapsible troubleshooting panel below error notice, appends web-llm error-specific guidance on model load failure |
| `src/floating-widget.jsx` | Troubleshooting accordion in StartModal when errors are present |
| `src/widget-bootstrap.js` | Admin-bar dot turns red with visible "WebLLM: WebGPU not available" label (was `console.debug` only) |
| `src/connector.jsx` | Red diagnostic panel in Settings > Connectors when issues detected, with note that worker tab can use a different browser |

## Testing
- Build passes (`npm run build` -- no errors, expected asset size warnings for web-llm)
- On a working WebGPU browser: no troubleshooting UI visible anywhere
- On a browser without WebGPU or with blocklisted GPU: troubleshooting panels appear with relevant chrome://flags steps