### PR TITLE
Update auto-pick heuristic to prefer newer model families

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ultimate-ai-connector-webllm",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ultimate-ai-connector-webllm",
-			"version": "1.0.2",
+			"version": "1.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@mlc-ai/web-llm": "^0.2.79"

--- a/src/worker.jsx
+++ b/src/worker.jsx
@@ -100,14 +100,26 @@ async function autoPickModel( list ) {
 	const unsupported = ( id ) => ! hasShaderF16 && /f16|BF16/i.test( id || '' );
 
 	const familyRank = ( id ) => {
-		if ( /Llama-3\.2.*Instruct/i.test( id ) ) return 6;
-		if ( /Llama-3\.1.*Instruct/i.test( id ) ) return 5;
-		if ( /Qwen2\.5.*Instruct/i.test( id ) ) return 4;
-		if ( /Phi-3.*mini.*Instruct/i.test( id ) ) return 3;
-		if ( /SmolLM2.*Instruct/i.test( id ) ) return 2;
-		if ( /TinyLlama.*Chat/i.test( id ) ) return 1;
+		if ( /^Qwen3-/i.test( id ) )                  return 10;
+		if ( /DeepSeek-R1/i.test( id ) )               return 9;
+		if ( /Ministral.*Instruct/i.test( id ) )       return 8;
+		if ( /Hermes-3/i.test( id ) )                  return 7;
+		if ( /Llama-3\.2.*Instruct/i.test( id ) )      return 6;
+		if ( /Llama-3\.1.*Instruct/i.test( id ) )      return 5;
+		if ( /Qwen2\.5-(?!Coder|Math).*Instruct/i.test( id ) ) return 4;
+		if ( /gemma-2-.*-it/i.test( id ) )             return 3;
+		if ( /Phi-3.*instruct/i.test( id ) )           return 2;
+		if ( /SmolLM2.*Instruct/i.test( id ) )         return 1;
 		return 0;
 	};
+
+	// Chat-capable models use various naming conventions: "Instruct",
+	// "Chat", "-it" (Gemma), "R1-Distill" (DeepSeek), "Hermes", "Qwen3"
+	// (no suffix), "Ministral-*-Instruct", "Reasoning", "zephyr". Match
+	// broadly and rely on the embed/reranker/base exclusion to filter
+	// non-chat models.
+	const isChatCapable = ( id ) =>
+		/instruct|chat|-it-|R1-Distill|Hermes|^Qwen3-|Ministral.*(?:Instruct|Reasoning)|zephyr/i.test( id );
 
 	const candidates = list
 		.map( ( m ) => ( {
@@ -117,16 +129,16 @@ async function autoPickModel( list ) {
 		.filter(
 			( m ) =>
 				m.id &&
-				! /embed|reranker/i.test( m.id ) &&
-				/instruct|chat/i.test( m.id ) &&
+				! /embed|reranker|Base-\d/i.test( m.id ) &&
+				isChatCapable( m.id ) &&
 				! unsupported( m.id ) &&
 				m.vram <= budgetMB
 		);
 
 	if ( candidates.length === 0 ) {
 		// Nothing fits the budget — fall back to absolute smallest
-		// supported instruct model.
-		const anyInstruct = list
+		// supported chat model.
+		const anyChat = list
 			.map( ( m ) => ( {
 				id: m.model_id || m.id,
 				vram: typeof m.vram_required_MB === 'number' ? m.vram_required_MB : 99999,
@@ -134,12 +146,12 @@ async function autoPickModel( list ) {
 			.filter(
 				( m ) =>
 					m.id &&
-					! /embed|reranker/i.test( m.id ) &&
-					/instruct|chat/i.test( m.id ) &&
+					! /embed|reranker|Base-\d/i.test( m.id ) &&
+					isChatCapable( m.id ) &&
 					! unsupported( m.id )
 			)
 			.sort( ( a, b ) => a.vram - b.vram );
-		return anyInstruct[ 0 ]?.id || '';
+		return anyChat[ 0 ]?.id || '';
 	}
 
 	// Prefer newer family, then larger model within the family (bigger = smarter).


### PR DESCRIPTION
## Summary

- Updates `familyRank` from 6 tiers to 10, placing Qwen3 at the top followed by DeepSeek-R1, Ministral, and Hermes 3
- Broadens the candidate filter from `instruct|chat` to a new `isChatCapable()` function that recognizes all naming conventions in the catalog (Gemma `-it`, DeepSeek `R1-Distill`, bare `Qwen3-`, `Hermes`, `zephyr`)
- Adds `Base-\d` to the exclusion list to filter out non-chat base models

51 chat-capable models (including all of Qwen3, DeepSeek-R1, Hermes 3, and Gemma 2) were previously invisible to auto-pick because they didn't match the `instruct|chat` filter. First-time users with a capable GPU will now get Qwen3-8B instead of Llama-3.2-3B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic model selection to better identify and prioritize high-quality chat and reasoning models, expanding support across additional model families and naming conventions for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->