### PR TITLE
GH#28: rank Ministral Reasoning models at same level as Instruct

### DIFF
--- a/src/worker.jsx
+++ b/src/worker.jsx
@@ -104,7 +104,7 @@ async function autoPickModel( list ) {
 	const familyRank = ( id ) => {
 		if ( /^Qwen3-/i.test( id ) )                  return 10;
 		if ( /DeepSeek-R1/i.test( id ) )               return 9;
-		if ( /Ministral.*Instruct/i.test( id ) )       return 8;
+		if ( /Ministral.*(?:Instruct|Reasoning)/i.test( id ) ) return 8;
 		if ( /Hermes-3/i.test( id ) )                  return 7;
 		if ( /Llama-3\.2.*Instruct/i.test( id ) )      return 6;
 		if ( /Llama-3\.1.*Instruct/i.test( id ) )      return 5;


### PR DESCRIPTION
## Summary

Ministral Reasoning model variants were treated as chat-capable by `isChatCapable()` (line 124) but fell through to rank `0` in `familyRank()` because the ranking regex only matched `Ministral.*Instruct`. This caused older model families to win the auto-selection preference order unexpectedly when a Reasoning variant was available.

## Change

**`src/worker.jsx:107`** — update `familyRank` regex to match both `Instruct` and `Reasoning` Ministral variants:

```diff
-		if ( /Ministral.*Instruct/i.test( id ) )       return 8;
+		if ( /Ministral.*(?:Instruct|Reasoning)/i.test( id ) ) return 8;
```

This aligns `familyRank` with `isChatCapable`, which already used `Ministral.*(?:Instruct|Reasoning)`.

## Runtime Testing

**Risk level**: Low — single-line regex change in model ranking logic. No API endpoints, no state machines, no auth paths affected.

**Self-assessed**: The regex change is mechanically correct — `(?:Instruct|Reasoning)` is a non-capturing alternation that extends the existing pattern. The `isChatCapable` function at line 124 already uses this exact pattern, confirming it is the intended form.

Resolves #28

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.234 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 54s and 2,077 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced model selection logic to consistently prioritize Ministral Reasoning model variants alongside Ministral Instruct variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->