### PR TITLE
chore: upgrade GitHub Actions from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate release version
         run: |
@@ -74,7 +74,7 @@ jobs:
           coverage: none
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -89,7 +89,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PLUGIN_SLUG }}-zip
           path: ${{ env.PLUGIN_SLUG }}.zip
@@ -103,3 +103,4 @@ jobs:
           prerelease: ${{ env.IS_PRERELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions action versions to eliminate Node.js 20 deprecation warnings ahead of the June 2, 2026 forced migration and September 16, 2026 removal.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `softprops/action-gh-release` | `@v2` (Node 20) | `@v2` + `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` |

`shivammathur/setup-php@v2` was already on Node 24 (v2.37.0) — no change needed.

## Runtime Testing

Risk: **Low** — CI configuration change only. No application code modified.

Self-assessed: changes are mechanical version pin upgrades per the upstream deprecation table. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var is the documented workaround for `softprops/action-gh-release@v2` until upstream ships a Node 24 release.

Resolves #30