### PR TITLE
t034: fix apiFetch middleware callback indentation

### DIFF
--- a/src/apifetch-middleware.js
+++ b/src/apifetch-middleware.js
@@ -99,48 +99,48 @@ if ( ! apiFetch || typeof apiFetch.use !== 'function' ) {
 	console.warn( '[WebLLM] wp.apiFetch unavailable; middleware not registered.' );
 } else {
 	apiFetch.use( async ( options, next ) => {
-	const path = options.path || '';
-	const data = options.data || null;
+		const path = options.path || '';
+		const data = options.data || null;
 
-	const isOurs =
-		isWebLlmGenerateRequest( path, data ) || isWebLlmAbilityRequest( path );
+		const isOurs =
+			isWebLlmGenerateRequest( path, data ) || isWebLlmAbilityRequest( path );
 
-	if ( ! isOurs ) {
-		return next( options );
-	}
+		if ( ! isOurs ) {
+			return next( options );
+		}
 
-	// Widget not mounted yet (early page load, before footer bootstrap
-	// finishes). Fall through — the server-side 503 path is still a safety
-	// net if the broker has no worker attached.
-	const widget = window.webllmWidget;
-	if ( ! widget ) {
-		return next( options );
-	}
+		// Widget not mounted yet (early page load, before footer bootstrap
+		// finishes). Fall through — the server-side 503 path is still a safety
+		// net if the broker has no worker attached.
+		const widget = window.webllmWidget;
+		if ( ! widget ) {
+			return next( options );
+		}
 
-	let status;
-	try {
-		status = await widget.getStatus();
-	} catch ( e ) {
-		return next( options );
-	}
+		let status;
+		try {
+			status = await widget.getStatus();
+		} catch ( e ) {
+			return next( options );
+		}
 
-	if ( status && status.state === 'ready' ) {
-		return next( options );
-	}
+		if ( status && status.state === 'ready' ) {
+			return next( options );
+		}
 
-	try {
-		await widget.promptAndLoad();
-		return next( options );
-	} catch ( err ) {
-		const errorMessage =
-			( err && err.message ) || 'WebLLM model is not loaded.';
-		// WP_Error-shaped rejection so the editor renders a clean notice
-		// instead of `[object Object]`.
-		return Promise.reject( {
-			code: 'webllm_not_ready',
-			message: errorMessage,
-			data: { status: 503 },
-		} );
-	}
-} );
+		try {
+			await widget.promptAndLoad();
+			return next( options );
+		} catch ( err ) {
+			const errorMessage =
+				( err && err.message ) || 'WebLLM model is not loaded.';
+			// WP_Error-shaped rejection so the editor renders a clean notice
+			// instead of `[object Object]`.
+			return Promise.reject( {
+				code: 'webllm_not_ready',
+				message: errorMessage,
+				data: { status: 503 },
+			} );
+		}
+	} );
 }


### PR DESCRIPTION
## Summary

Fixes inconsistent indentation in `src/apifetch-middleware.js` flagged by CodeRabbit in PR #18 (nitpick, unaddressed at merge time).

The middleware callback body passed to `apiFetch.use()` was indented at the same level as the `apiFetch.use(` call rather than one level deeper inside the arrow function. This is a pure formatting fix — no logic changes.

## Changes

- **EDIT** `src/apifetch-middleware.js:101-145` — added one tab of indentation to the entire arrow function body and moved the closing `} );` to align with the `apiFetch.use(` call.

## Verification

- `git diff` shows 38 insertions and 38 deletions — purely whitespace.
- All logic (classifiers, widget checks, promptAndLoad, rejection shape) is unchanged.

Resolves #34