### PR TITLE
chore: lower minimum WordPress requirement from 7.0 to 6.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ No third-party API. No API keys. No per-token cost. Model weights live in the br
 ## Project Overview
 
 - **Type**: WordPress plugin (`wordpress-plugin` composer package type)
-- **Minimum WordPress**: 7.0 (uses the bundled AI Client SDK)
+- **Minimum WordPress**: 6.9 (uses the bundled AI Client SDK)
 - **Minimum PHP**: 7.4 (composer platform pinned to 8.2.0)
 - **Licence**: GPL-2.0-or-later
 - **Entry point**: `ultimate-ai-connector-webllm.php`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ultimate AI Connector for WebLLM (Browser GPU)
 
-A WordPress 7.0+ plugin that adds a **WebLLM** provider to the bundled AI Client SDK. Inference runs **entirely in the user's browser** on WebGPU via [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm) — no API keys, no data leaving the device, no usage fees.
+A WordPress 6.9+ plugin that adds a **WebLLM** provider to the bundled AI Client SDK. Inference runs **entirely in the user's browser** on WebGPU via [`@mlc-ai/web-llm`](https://github.com/mlc-ai/web-llm) — no API keys, no data leaving the device, no usage fees.
 
 A SharedWorker running in the browser acts as the GPU; the WordPress site brokers requests so any logged-in device on the install (a phone, a tablet, a second laptop) can send a prompt and have it served by the desktop GPU.
 
@@ -16,7 +16,7 @@ This is the right answer when:
 
 ## Quick start
 
-1. Install and activate the plugin on WordPress 7.0+.
+1. Install and activate the plugin on WordPress 6.9+.
 2. Visit any wp-admin page. A small floating icon appears in the corner.
 3. The first time you click an AI feature (e.g. the excerpt generator in WordPress/ai), a start modal appears showing the recommended model for your hardware. Click **Start**.
 4. Wait for the model to download (once per browser — cached in IndexedDB after that).
@@ -60,7 +60,7 @@ The WordPress site is the broker. Any device on the install can submit a prompt;
 
 ## Requirements
 
-- **WordPress 7.0+** (uses the bundled AI Client SDK).
+- **WordPress 6.9+** (uses the bundled AI Client SDK).
 - **PHP 7.4+**.
 - A modern desktop browser with **WebGPU** enabled. Chrome 124+ / Edge 124+ for the zero-config SharedWorker runtime. On Linux you may need to enable `chrome://flags/#enable-unsafe-webgpu`, `#enable-vulkan`, and `#ignore-gpu-blocklist`.
 - A GPU with **at least ~4 GB of VRAM** for the smallest useful chat models. Bigger models want 8–16 GB. WebLLM will fall back to SwiftShader on machines without a real GPU but inference will be unusably slow.
@@ -77,7 +77,7 @@ npm install
 npm run build
 ```
 
-Symlink or copy the directory into `wp-content/plugins/`, then network-activate (or activate per-site) on a WordPress 7.0+ install.
+Symlink or copy the directory into `wp-content/plugins/`, then network-activate (or activate per-site) on a WordPress 6.9+ install.
 
 ## Use
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Ultimate AI Connector for WebLLM (Browser GPU) ===
 Contributors: ultimatemultisite
 Tags: ai, webllm, webgpu, llm, on-device
-Requires at least: 7.0
+Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 1.2.0
@@ -12,7 +12,7 @@ Run LLM inference entirely in the user's browser via WebGPU + WebLLM. Routes thr
 
 == Description ==
 
-This plugin registers a `WebLLM (Browser GPU)` provider with the WordPress 7.0 AI Client. Inference runs **entirely in your browser** using [WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU — no API keys, no data leaving the device.
+This plugin registers a `WebLLM (Browser GPU)` provider with the WordPress AI Client. Inference runs **entirely in your browser** using [WebLLM](https://github.com/mlc-ai/web-llm) on WebGPU — no API keys, no data leaving the device.
 
 In Chrome 124+ and Edge 124+, a SharedWorker loads the model automatically when you open any wp-admin page — no dedicated tab required. The model stays loaded as you navigate between admin pages. On older browsers, a dedicated Tools → WebLLM Worker tab acts as the fallback. Because the WordPress site itself acts as a broker, any logged-in device on the same install — phone, tablet, second laptop — can submit a request and have it served by your desktop GPU.
 

--- a/todo/tasks/t012-brief.md
+++ b/todo/tasks/t012-brief.md
@@ -56,7 +56,7 @@ Replace the "Quick start" section with:
 ```markdown
 ## Quick start
 
-1. Install and activate the plugin on WordPress 7.0+.
+1. Install and activate the plugin on WordPress 6.9+.
 2. Visit any wp-admin page. A small floating icon appears in the corner.
 3. The first time you click an AI feature (e.g. the excerpt generator in WordPress/ai), a start modal appears showing the recommended model for your hardware. Click **Start**.
 4. Wait for the model to download (once per browser — cached in IndexedDB after that).

--- a/ultimate-ai-connector-webllm.php
+++ b/ultimate-ai-connector-webllm.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ultimate AI Connector for WebLLM (Browser GPU)
  * Description: Registers an AI Client provider that runs LLM inference entirely in the user's browser via WebGPU + WebLLM. A persistent worker tab acts as the GPU; the WordPress site brokers requests so any logged-in device (phone, tablet, second laptop) can use it.
- * Requires at least: 6.0
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.2.0
  * Author: Ultimate Multisite Community

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 const path = require( 'path' );
 
 // Three entries:
-//   connector.js      — ES module loaded by WP 7.0 Connectors page (Script Modules API).
+//   connector.js      — ES module loaded by WP 6.9 Connectors page (Script Modules API).
 //   worker.js         — classic script loaded on the Tools → WebLLM Worker admin page,
 //                       bundles @mlc-ai/web-llm so it ships as one self-contained file.
 //   shared-worker.js  — SharedWorker entry point (p001 Phase 2). Hosts a single


### PR DESCRIPTION
## Summary

The WordPress AI Client SDK is now available in WordPress 6.9, so the 7.0 minimum was unnecessarily restrictive.

## Changes

- Plugin header `Requires at least` → `6.9`
- `readme.txt` minimum version → `6.9`; removed version number from AI Client reference
- `README.md` — all four `WordPress 7.0+` references updated to `6.9+`
- `AGENTS.md` — project overview minimum version updated
- `webpack.config.js` — comment updated to match

## Verification

Tested on WordPress 6.9.4 via browser agent:
- Plugin activates cleanly — no version compatibility error
- REST `/webllm/v1/status` returns valid JSON
- Worker page renders (model selector populated, WebGPU state detected correctly)
- Build passes — `npm run build` produces all assets with zero errors## Summary

Implements Phases 1, 2, 3, and 5 of the WP 6.9 compatibility plan (t226, issue #1126). The plugin now loads on WordPress 6.9 by bundling the WP 7.0 AI APIs that are not available in core until 7.0.

## What changed

**Phase 1 — Bundle php-ai-client SDK** (`lib/php-ai-client/`)
- Copy of the `WordPress\AiClient\*` SDK (145 PHP files) from `wp-includes/php-ai-client/`
- Custom `spl_autoload_register` in `CompatLoader` loads these only when `WordPress\AiClient\AiClient` is not already defined (WP 7.0 core wins)

**Phase 2 — WP AI Client bridge polyfill** (`lib/ai-client/`)
- `WP_AI_Client_Prompt_Builder` and `WP_AI_Client_Ability_Function_Resolver` from WP 7.0
- 4 adapter classes: cache, event dispatcher, HTTP client, discovery strategy
- Loaded with `class_exists()` guards

**Phase 3 — Connectors credential helpers** (`includes/Compat/wp-connectors-polyfill.php`)
- Polyfills `_wp_connectors_get_provider_settings()` and `_wp_connectors_get_real_api_key()` using the same `connectors_ai_{provider}_api_key` option names as WP 7.0
- Credentials entered on WP 6.9 are zero-migration compatible with WP 7.0

**Phase 5 — Lower version requirement**
- `Requires at least: 7.0` → `Requires at least: 6.9` in plugin header
- `CompatLoader::load()` runs in `gratis-ai-agent.php` immediately after the Composer vendor autoloader and before `xwp_load_app()`

## Not included

Phase 4 (React admin page for Connectors on WP 6.9) is tracked in #1130.

## Verification

- All new PHP files pass `php -l` (syntax check)
- On WP 7.0: `class_exists('WordPress\AiClient\AiClient', false)` returns true before CompatLoader's autoloader fires, so no SDK files are loaded twice
- On WP 6.9: CompatLoader registers the spl autoloader, bridge classes are `require_once`'d, and connector functions are available

For #1126


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 15m and 34,635 tokens on this as a headless worker.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 29m and 17,577 tokens on this with the user in an interactive session.
