### PR TITLE
fix: make chrome://flags insecure-origin link clickable and show real site URL

### DIFF
--- a/src/connector.jsx
+++ b/src/connector.jsx
@@ -222,7 +222,12 @@ function WebLlmConnectorCard( { label, description, logo } ) {
 							{ issue.steps && (
 								<ol style={ { margin: '4px 0 0 0', paddingLeft: 20 } }>
 									{ issue.steps.map( ( step, si ) => (
-										<li key={ si } style={ { marginBottom: 2 } }>{ step.text }</li>
+									<li key={ si } style={ { marginBottom: 2 } }>
+										{ step.href
+											? <>{ step.text }<a href={ step.href }>{ step.href }</a>{ step.textSuffix || '' }</>
+											: step.text
+										}
+									</li>
 									) ) }
 								</ol>
 							) }

--- a/src/floating-widget.jsx
+++ b/src/floating-widget.jsx
@@ -572,7 +572,11 @@ function StartModal( {
 						),
 						issue.steps && h( 'ol', { style: { margin: '4px 0 0 0', paddingLeft: 18, lineHeight: 1.5 } },
 							issue.steps.map( ( step, si ) =>
-								h( 'li', { key: si, style: { marginBottom: 2 } }, step.text )
+								h( 'li', { key: si, style: { marginBottom: 2 } },
+									step.href
+										? [ step.text, h( 'a', { key: 'link', href: step.href }, step.href ), step.textSuffix || '' ]
+										: step.text
+								)
 							)
 						)
 					)

--- a/src/webgpu-troubleshooter.js
+++ b/src/webgpu-troubleshooter.js
@@ -33,9 +33,16 @@
  * Safe to call in any context (main thread, SharedWorker). Returns issues
  * only when problems are detected.
  *
+ * @param {string} [siteUrl] - The WordPress site origin (e.g. http://mysite.local).
+ *   Defaults to window.location.origin when available. Used in remediation steps
+ *   so the user sees their real URL rather than a generic placeholder.
  * @return {Promise<WebGpuDiagnostic>}
  */
-export async function diagnoseWebGpu() {
+export async function diagnoseWebGpu( siteUrl ) {
+	if ( ! siteUrl && typeof window !== 'undefined' && window.location?.origin ) {
+		siteUrl = window.location.origin;
+	}
+	siteUrl = siteUrl || '';
 	const result = {
 		webgpuApiPresent: false,
 		adapterAvailable: false,
@@ -68,7 +75,7 @@ export async function diagnoseWebGpu() {
 			severity: 'error',
 			title: 'WebGPU API not available',
 			description: 'This browser does not expose the WebGPU API, which is required for in-browser AI inference.',
-			steps: buildNoWebGpuSteps( result.isInsecureContext ),
+			steps: buildNoWebGpuSteps( result.isInsecureContext, siteUrl ),
 		} );
 		return result;
 	}
@@ -145,7 +152,7 @@ export async function diagnoseWebGpu() {
 			severity: 'warning',
 			title: 'Site served over HTTP',
 			description: 'This WordPress site is not using HTTPS. Some browsers restrict WebGPU features on insecure origins. If you experience issues, either enable HTTPS or add this origin to Chrome\'s insecure-origins allowlist.',
-			steps: buildInsecureContextSteps(),
+			steps: buildInsecureContextSteps( siteUrl ),
 		} );
 	}
 
@@ -174,7 +181,7 @@ export function diagnoseWebLlmError( error ) {
 			severity: 'error',
 			title: 'WebGPU not available',
 			description: 'The AI engine requires WebGPU but it is not available in this browser.',
-			steps: buildNoWebGpuSteps( false ),
+			steps: buildNoWebGpuSteps( false, siteUrl ),
 		};
 	}
 
@@ -230,9 +237,10 @@ export function diagnoseWebLlmError( error ) {
 
 /**
  * @param {boolean} isInsecureContext
+ * @param {string}  [siteUrl] - The WordPress site origin, shown in the remediation step.
  * @return {Array<Object>}
  */
-function buildNoWebGpuSteps( isInsecureContext ) {
+function buildNoWebGpuSteps( isInsecureContext, siteUrl ) {
 	const steps = [
 		{
 			text: 'Use a supported browser: Chrome 113+ or Edge 113+ on desktop. Safari and Firefox have limited or no WebGPU support.',
@@ -241,10 +249,13 @@ function buildNoWebGpuSteps( isInsecureContext ) {
 	];
 
 	if ( isInsecureContext ) {
+		const urlExample = siteUrl || 'http://mysite.local';
 		steps.push( {
-			text: 'Your site is served over HTTP. WebGPU requires a secure context. Either set up HTTPS, or in Chrome/Edge go to chrome://flags/#unsafely-treat-insecure-origin-as-secure and add your site\'s URL (e.g. http://mysite.local).',
+			text: 'Your site is served over HTTP. WebGPU requires a secure context. Either set up HTTPS, or in Chrome/Edge open ',
+			textSuffix: ' and add your site\'s URL (' + urlExample + ') to the list.',
 			type: 'chrome-flag',
 			flag: '#unsafely-treat-insecure-origin-as-secure',
+			href: 'chrome://flags/#unsafely-treat-insecure-origin-as-secure',
 		} );
 	}
 
@@ -343,18 +354,22 @@ function buildSoftwareRenderingSteps() {
 }
 
 /**
+ * @param {string} [siteUrl] - The WordPress site origin, shown in the remediation step.
  * @return {Array<Object>}
  */
-function buildInsecureContextSteps() {
+function buildInsecureContextSteps( siteUrl ) {
+	const urlExample = siteUrl || 'http://192.168.1.100';
 	return [
 		{
 			text: 'Recommended: Set up HTTPS for your WordPress site (e.g. via a reverse proxy or local certificate).',
 			type: 'action',
 		},
 		{
-			text: 'Quick workaround: In Chrome/Edge, go to chrome://flags/#unsafely-treat-insecure-origin-as-secure and add your site URL (e.g. http://192.168.1.100).',
+			text: 'Quick workaround: In Chrome/Edge, open ',
+			textSuffix: ' and add your site URL (' + urlExample + ') to the list.',
 			type: 'chrome-flag',
 			flag: '#unsafely-treat-insecure-origin-as-secure',
+			href: 'chrome://flags/#unsafely-treat-insecure-origin-as-secure',
 		},
 		{
 			text: 'After changing the flag, relaunch the browser.',
@@ -392,7 +407,10 @@ export function formatIssuesPlainText( diag ) {
 	return diag.issues.map( ( issue ) => {
 		let text = issue.title + ': ' + issue.description + '\n';
 		if ( issue.steps ) {
-			text += issue.steps.map( ( s, i ) => '  ' + ( i + 1 ) + '. ' + s.text ).join( '\n' );
+			text += issue.steps.map( ( s, i ) => {
+				const stepText = s.text + ( s.href ? s.href : '' ) + ( s.textSuffix || '' );
+				return '  ' + ( i + 1 ) + '. ' + stepText;
+			} ).join( '\n' );
 		}
 		return text;
 	} ).join( '\n\n' );

--- a/src/worker.jsx
+++ b/src/worker.jsx
@@ -470,23 +470,27 @@ function App() {
 		gpuDiag.issues.map( ( issue, idx ) =>
 			h( 'div', { key: idx, style: { marginTop: 10 } },
 				h( 'strong', { style: { color: issue.severity === 'error' ? '#cc1818' : '#996800' } }, issue.title ),
-				h( 'p', { style: { margin: '4px 0' } }, issue.description ),
-				issue.steps && h( 'ol', { style: { margin: '6px 0 0 0', paddingLeft: 20 } },
-					issue.steps.map( ( step, si ) =>
-						h( 'li', {
-							key: si,
-							style: {
-								marginBottom: 4,
-								...(
-									step.type === 'chrome-flag'
-										? { fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12 }
-										: {}
-								),
-							},
-						}, step.text )
+			h( 'p', { style: { margin: '4px 0' } }, issue.description ),
+			issue.steps && h( 'ol', { style: { margin: '6px 0 0 0', paddingLeft: 20 } },
+				issue.steps.map( ( step, si ) =>
+					h( 'li', {
+						key: si,
+						style: {
+							marginBottom: 4,
+							...(
+								step.type === 'chrome-flag'
+									? { fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12 }
+									: {}
+							),
+						},
+					},
+					step.href
+						? [ step.text, h( 'a', { key: 'link', href: step.href }, step.href ), step.textSuffix || '' ]
+						: step.text
 					)
 				)
 			)
+		)
 		)
 	);
 


### PR DESCRIPTION
## What

In the WebGPU troubleshooter, the `chrome://flags/#unsafely-treat-insecure-origin-as-secure` URL was buried as plain text inside step strings. Users had to read it, memorise it, and type it manually into the address bar.

## Changes

**`src/webgpu-troubleshooter.js`**
- `diagnoseWebGpu()` now accepts an optional `siteUrl` parameter, falling back to `window.location.origin` automatically — so callers don't need to change.
- Both insecure-context step builders receive the real site URL; the placeholder strings (`http://mysite.local`, `http://192.168.1.100`) are only used as fallbacks when the URL is unavailable (e.g. SharedWorker context).
- Steps with a chrome://flags URL are restructured into `text` + `href` + `textSuffix` so renderers can wrap the URL in an `<a>` element.
- `formatIssuesPlainText()` (used in non-React contexts) reconstructs the full sentence by concatenating the three parts.

**`src/worker.jsx`**, **`src/connector.jsx`**, **`src/floating-widget.jsx`**
- Step renderer: when `step.href` is present, outputs `step.text` + `<a href={step.href}>` + `step.textSuffix`; otherwise falls back to `step.text` as before — no change for all other step types.

## Result

The remediation step now reads:

> Your site is served over HTTP. WebGPU requires a secure context. Either set up HTTPS, or in Chrome/Edge open **chrome://flags/#unsafely-treat-insecure-origin-as-secure** and add your site's URL (http://yoursite.local) to the list.

The URL is a one-click link and the example shows the user's actual WordPress origin instead of a hardcoded placeholder.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 14,224 tokens on this with the user in an interactive session.