### PR TITLE
GH#43: fix: gate temperature/top_p defaults on isGemma4 in transformers engine

### DIFF
--- a/src/transformers-engine.js
+++ b/src/transformers-engine.js
@@ -153,9 +153,12 @@ export function createTransformersEngine() {
 
 			const messages = request.messages || [];
 			const maxTokens = request.max_tokens || 1024;
-			// Gemma 4 recommended defaults: temp=1.0, top_p=0.95.
-			const temperature = typeof request.temperature === 'number' ? request.temperature : 1.0;
-			const topP = typeof request.top_p === 'number' ? request.top_p : 0.95;
+			const isG4 = isGemma4( currentModelId );
+			// Gemma 4 recommended defaults: temp=1.0, top_p=0.95. Other models use standard defaults.
+			const defaultTemp = isG4 ? 1.0 : 0.7;
+			const defaultTopP = isG4 ? 0.95 : 0.9;
+			const temperature = typeof request.temperature === 'number' ? request.temperature : defaultTemp;
+			const topP = typeof request.top_p === 'number' ? request.top_p : defaultTopP;
 			const t0 = Date.now();
 
 			if ( isGemma4( currentModelId ) ) {


### PR DESCRIPTION
## Summary

Gated temperature/top_p defaults on isGemma4(currentModelId) in src/transformers-engine.js. Gemma 4 keeps temp=1.0/top_p=0.95; other models (Gemma 3, Qwen 3) now use standard defaults (0.7/0.9). Fixes the misleading 'Gemma 4 recommended defaults' comment that was applied unconditionally to all models.

## Files Changed

src/transformers-engine.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Code review: defaults are now conditional on isGemma4(). Non-Gemma4 callers that omit temperature/top_p now receive 0.7/0.9 instead of 1.0/0.95. Build confirmed with npm run build.

Resolves #43


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 7,629 tokens on this as a headless worker.