### PR TITLE
fix: include ONNX models in loadModel auto-pick candidate list

### DIFF
--- a/src/shared-worker.js
+++ b/src/shared-worker.js
@@ -177,9 +177,18 @@ async function autoPickModel( list ) {
 	const unsupported = ( id ) =>
 		! hasShaderF16 && /f16|BF16/i.test( id || '' );
 
+	// Helper: return true for models intended for chat/instruction use.
+	// WebLLM model IDs contain "instruct" or "chat"; ONNX models from the
+	// Transformers.js engine use a "-it-" (instruction-tuned) suffix instead,
+	// but carry a human-readable name that contains "Instruct" or "chat".
+	const isChatModel = ( id, name ) =>
+		/instruct|chat/i.test( id ) ||
+		/instruct|chat/i.test( name || '' );
+
 	const candidates = list
 		.map( ( m ) => ( {
 			id: m.model_id || m.id,
+			name: m.name || '',
 			vram:
 				typeof m.vram_required_MB === 'number'
 					? m.vram_required_MB
@@ -189,7 +198,7 @@ async function autoPickModel( list ) {
 			( m ) =>
 				m.id &&
 				! /embed|reranker/i.test( m.id ) &&
-				/instruct|chat/i.test( m.id ) &&
+				isChatModel( m.id, m.name ) &&
 				! unsupported( m.id ) &&
 				m.vram <= budgetMB
 		);
@@ -200,6 +209,7 @@ async function autoPickModel( list ) {
 		const anyInstruct = list
 			.map( ( m ) => ( {
 				id: m.model_id || m.id,
+				name: m.name || '',
 				vram:
 					typeof m.vram_required_MB === 'number'
 						? m.vram_required_MB
@@ -209,7 +219,7 @@ async function autoPickModel( list ) {
 				( m ) =>
 					m.id &&
 					! /embed|reranker/i.test( m.id ) &&
-					/instruct|chat/i.test( m.id ) &&
+					isChatModel( m.id, m.name ) &&
 					! unsupported( m.id )
 			)
 			.sort( ( a, b ) => a.vram - b.vram );
@@ -497,7 +507,13 @@ async function handlePortMessage( port, event ) {
 			let modelId = msg.modelId || null;
 			if ( ! modelId ) {
 				let combinedList = [];
-				try { combinedList = await createWebLlmEngine().getModelList().catch( () => [] ); } catch ( _ ) {}
+				try {
+					const [ wM, tM ] = await Promise.all( [
+						createWebLlmEngine().getModelList().catch( () => [] ),
+						createTransformersEngine().getModelList().catch( () => [] ),
+					] );
+					combinedList = [ ...tM, ...wM ];
+				} catch ( _ ) {}
 				modelId = await autoPickModel( combinedList );
 			}
 			if ( ! modelId ) {


### PR DESCRIPTION
## Summary

When `loadModel` is called without a `modelId`, the auto-pick fallback only fetched the WebLLM model list, so high-priority ONNX models (Gemma 4, Gemma 3) from the Transformers.js engine were never candidates for automatic selection — even though they appear correctly in the handshake response.

## Changes

**`src/shared-worker.js`**

1. **`loadModel` case** (lines 507-518): fetch both WebLLM and Transformers model lists in parallel via `Promise.all`, mirroring the pattern already used in the `handshake` case. ONNX models are prepended so they have positional priority before the sort.

2. **`autoPickModel` — `isChatModel` helper** (lines 180-186): WebLLM model IDs embed `instruct`/`chat` in the id string. ONNX models use `-it-` (instruction-tuned) in the id but carry `Instruct` in the human-readable `name` field. Without this companion fix, the freshly-fetched ONNX models would still be silently filtered out by the old `/instruct|chat/i.test(m.id)` check.

3. **`autoPickModel` — `name` field preserved** through `.map()` in both the primary and fallback candidate paths.

## Testing

- `node --check src/shared-worker.js` — syntax clean
- Logic matches the existing `handshake` case (lines 476-481) which already correctly combines both engine lists

Resolves #44

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 9m and 15,252 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-selection of chat and instruction models with enhanced detection for various naming patterns
  * Extended model discovery to search multiple model sources when auto-selecting without an explicit model specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->