### PR TITLE
fix: ONNX models get priority in auto-pick — familyRank, isChatModel, dedup helper

### DIFF
--- a/src/shared-worker.js
+++ b/src/shared-worker.js
@@ -118,6 +118,29 @@ function setState( next, extra = {} ) {
 }
 
 // ---------------------------------------------------------------------------
+// Combined model list helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch model descriptors from all available engines and merge them.
+ *
+ * ONNX (Transformers.js) models are prepended so they have positional
+ * priority where `familyRank` ties. Each inner `.catch( () => [] )`
+ * prevents a single failing engine from poisoning the combined list;
+ * `Promise.all` itself therefore never rejects.
+ *
+ * @return {Promise<Array<object>>} Merged list: [ ...tM, ...wM ].
+ */
+async function getCombinedModelList() {
+	const [ wM, tM ] = await Promise.all( [
+		createWebLlmEngine().getModelList().catch( () => [] ),
+		createTransformersEngine().getModelList().catch( () => [] ),
+	] );
+	// ONNX first so it has positional priority where rank ties.
+	return [ ...tM, ...wM ];
+}
+
+// ---------------------------------------------------------------------------
 // Auto-pick model heuristic (lifted from src/worker.jsx)
 // ---------------------------------------------------------------------------
 
@@ -152,6 +175,17 @@ async function autoPickModel( list ) {
 	} catch ( e ) {}
 
 	const familyRank = ( id ) => {
+		// ONNX (Transformers.js) families — ranked above WebLLM families so
+		// curated ONNX builds win the primary sort when both fit the VRAM budget.
+		if ( /gemma-4.*-it-ONNX/i.test( id ) ) {
+			return 9;
+		}
+		if ( /gemma-3.*-it-ONNX/i.test( id ) ) {
+			return 8;
+		}
+		if ( /Qwen3.*ONNX/i.test( id ) ) {
+			return 7;
+		}
 		if ( /Llama-3\.2.*Instruct/i.test( id ) ) {
 			return 6;
 		}
@@ -481,14 +515,7 @@ async function handlePortMessage( port, event ) {
 
 	switch ( msg.type ) {
 		case 'handshake': {
-			let allModels = [];
-			try {
-				const [ wM, tM ] = await Promise.all( [
-					createWebLlmEngine().getModelList().catch( () => [] ),
-					createTransformersEngine().getModelList().catch( () => [] ),
-				] );
-				allModels = [ ...tM, ...wM ];
-			} catch ( _ ) {}
+			const allModels = await getCombinedModelList();
 			reply( { type: 'handshake', version: VERSION, state: snapshot(), models: allModels } );
 			break;
 		}
@@ -506,15 +533,7 @@ async function handlePortMessage( port, event ) {
 		case 'loadModel': {
 			let modelId = msg.modelId || null;
 			if ( ! modelId ) {
-				let combinedList = [];
-				try {
-					const [ wM, tM ] = await Promise.all( [
-						createWebLlmEngine().getModelList().catch( () => [] ),
-						createTransformersEngine().getModelList().catch( () => [] ),
-					] );
-					combinedList = [ ...tM, ...wM ];
-				} catch ( _ ) {}
-				modelId = await autoPickModel( combinedList );
+				modelId = await autoPickModel( await getCombinedModelList() );
 			}
 			if ( ! modelId ) {
 				reply( { type: 'error', error: 'No model available to load' } );

--- a/src/transformers-engine.js
+++ b/src/transformers-engine.js
@@ -44,7 +44,7 @@ const CURATED_MODELS = [
 	{ id: 'onnx-community/gemma-3-4b-it-ONNX', name: 'Gemma 3 4B Instruct (ONNX)', vram_required_MB: 3200, dtype: 'q4f16', family: 'gemma3' },
 	{ id: 'onnx-community/gemma-3-1b-it-ONNX', name: 'Gemma 3 1B Instruct (ONNX)', vram_required_MB: 1200, dtype: 'q4f16', family: 'gemma3' },
 	// Qwen 3
-	{ id: 'onnx-community/Qwen3-0.6B-ONNX', name: 'Qwen3 0.6B (ONNX)', vram_required_MB: 800, dtype: 'q4', family: 'qwen' },
+	{ id: 'onnx-community/Qwen3-0.6B-ONNX', name: 'Qwen3 0.6B Chat (ONNX)', vram_required_MB: 800, dtype: 'q4', family: 'qwen' },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Three fixes from CodeRabbit review of PR #46:

### 1. `familyRank` — ONNX families now win the primary sort (HIGH)

`familyRank` previously only matched WebLLM-style IDs (`Llama-3.2…Instruct`, `Qwen2.5…Instruct`, etc.), returning `0` for every ONNX model. The positional prepend (`[ ...tM, ...wM ]`) had no effect because even a Llama-3.2 build (rank 6) beat every ONNX model (rank 0). Added three new patterns ahead of the WebLLM tier:

| Pattern | Rank |
|---|---|
| `/gemma-4.*-it-ONNX/i` | 9 |
| `/gemma-3.*-it-ONNX/i` | 8 |
| `/Qwen3.*ONNX/i` | 7 |

### 2. `isChatModel` — Qwen3 0.6B no longer silently filtered (HIGH)

The `isChatModel(/instruct|chat/i)` check excluded `onnx-community/Qwen3-0.6B-ONNX` because its name was `'Qwen3 0.6B (ONNX)'` — no "instruct" or "chat". Renamed the `CURATED_MODELS` entry to `'Qwen3 0.6B Chat (ONNX)'` (consistent with the other ONNX entries: `'Gemma 4 E4B Instruct (ONNX)'`, etc.).

### 3. `getCombinedModelList()` helper — eliminates duplicate fetch code (nitpick)

The identical 5-line dual-engine fetch was duplicated verbatim in `handshake` and `loadModel`. Extracted into `getCombinedModelList()`. Also removes the misleading outer `try/catch` — `Promise.all` never rejects when both inner promises already have `.catch(() => [])`.

## Files changed

- `EDIT: src/shared-worker.js` — `familyRank` extension + `getCombinedModelList()` helper + both call sites updated
- `EDIT: src/transformers-engine.js` — Qwen3 0.6B name includes "Chat"

## Verification

1. `familyRank('onnx-community/gemma-4-E4B-it-ONNX')` → 9 (was 0)
2. `familyRank('onnx-community/Qwen3-0.6B-ONNX')` → 7 (was 0)
3. `isChatModel('onnx-community/Qwen3-0.6B-ONNX', 'Qwen3 0.6B Chat (ONNX)')` → true (was false)
4. `getCombinedModelList()` appears once in source; both call sites use it.

Resolves #47
<!-- aidevops:sig -->