### PR TITLE
ops: restore health dashboard after cache naming migration (#52)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -87,13 +87,16 @@ t012,Phase 8 — Docs distignore readme updates,@themarcusquinn,docs/auto-dispat
 
 ## Done
 
-<!--TOON:done[6]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
+- [x] t013 Restore health dashboard after cache naming migration (#52) @superdav42 #ops ~30m risk:low logged:2026-05-11 completed:2026-05-11
+
+<!--TOON:done[7]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
 t005,Hook WebLLM into wpai_preferred_text_models filter,@themarcusquinn,bugfix/auto-dispatch,30m,,2026-04-07,,2026-04-08,done
 t006,Phase 2 — SharedWorker handler + MLCEngine wrapper,@themarcusquinn,feature/auto-dispatch,5h,,2026-04-07,,2026-04-08,done
 t007,Phase 3 — Floating widget UI + state machine,@themarcusquinn,feature/auto-dispatch,7h,,2026-04-07,,2026-04-08,done
 t008,Phase 4 — Bootstrap injector capability detection,@themarcusquinn,feature/auto-dispatch,3h,,2026-04-07,,2026-04-08,done
 t009,Phase 5 — Settings + connector card UI update,@themarcusquinn,feature/auto-dispatch,3h,,2026-04-07,,2026-04-08,done
 t010,Phase 6 — apiFetch middleware integration,@themarcusquinn,feature/auto-dispatch,5h,,2026-04-07,,2026-04-08,done
+t013,Restore health dashboard after cache naming migration (#52),@superdav42,ops,30m,30m,2026-05-11,,2026-05-11,done
 -->
 
 ## Declined


### PR DESCRIPTION
## Summary

- Fixes the stale supervisor health dashboard (issue #3) for this repo.
- Root cause: `stats-health-dashboard.sh` changed its cache file naming from `health-issue-{user}-supervisor-{slug}` to `health-issue-{user}-{slug}`. Repos with no recent activity (no open PRs, no assigned issues, no active workers) lost their cached issue pointers and the activity guard prevented recreation.

## Changes

- `TODO.md`: Records the completed operational task (t013) to maintain task history.

## Operational fix applied

1. Created new-format cache file pointing to dashboard issue #3.
2. Added `operator:superdav42` label to issue #3 so the identity check passes on every future stats cycle.
3. The next scheduled stats-wrapper run (22:15:50 UTC) refreshed the dashboard.

## Verification

- `gh issue view 3 --repo Ultimate-Multisite/ultimate-ai-connector-webllm` shows `updated_at: 2026-05-11T22:20:09Z` ✅
- Dashboard body: `last_refresh: 2026-05-11T22:17:52Z` ✅

Resolves #52

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.31 plugin for [OpenCode](https://opencode.ai) v1.14.48 with claude-sonnet-4-6 spent 23m and 51,828 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project task tracking documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-ai-connector-webllm/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->