### PR TITLE
GH#56: ops: document dashboard freshness remediation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -88,8 +88,9 @@ t012,Phase 8 — Docs distignore readme updates,@themarcusquinn,docs/auto-dispat
 ## Done
 
 - [x] t013 Restore health dashboard after cache naming migration (#52) @superdav42 #ops ~30m risk:low logged:2026-05-11 completed:2026-05-11
+- [x] t014 Refresh stale supervisor health dashboard (#56) @superdav42 #ops ~30m risk:low logged:2026-05-31 completed:2026-05-31
 
-<!--TOON:done[7]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
+<!--TOON:done[8]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
 t005,Hook WebLLM into wpai_preferred_text_models filter,@themarcusquinn,bugfix/auto-dispatch,30m,,2026-04-07,,2026-04-08,done
 t006,Phase 2 — SharedWorker handler + MLCEngine wrapper,@themarcusquinn,feature/auto-dispatch,5h,,2026-04-07,,2026-04-08,done
 t007,Phase 3 — Floating widget UI + state machine,@themarcusquinn,feature/auto-dispatch,7h,,2026-04-07,,2026-04-08,done
@@ -97,6 +98,7 @@ t008,Phase 4 — Bootstrap injector capability detection,@themarcusquinn,feature
 t009,Phase 5 — Settings + connector card UI update,@themarcusquinn,feature/auto-dispatch,3h,,2026-04-07,,2026-04-08,done
 t010,Phase 6 — apiFetch middleware integration,@themarcusquinn,feature/auto-dispatch,5h,,2026-04-07,,2026-04-08,done
 t013,Restore health dashboard after cache naming migration (#52),@superdav42,ops,30m,30m,2026-05-11,,2026-05-11,done
+t014,Refresh stale supervisor health dashboard (#56),@superdav42,ops,30m,30m,2026-05-31,,2026-05-31,done
 -->
 
 ## Declined
@@ -115,5 +117,5 @@ t013,Restore health dashboard after cache naming migration (#52),@superdav42,ops
 <!--/TOON:subtasks-->
 
 <!--TOON:summary{total,ready,pending,in_progress,in_review,done,declined,total_est,total_actual}:
-9,1,2,0,0,6,0,59h30m,
+11,1,2,0,0,8,0,60h,
 -->


### PR DESCRIPTION
## Summary

Recorded the dashboard freshness remediation in TODO.md and restored the local health issue cache pointer so the stats wrapper can update issue #3.

## Files Changed

TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check HEAD~1..HEAD; gh api repos/Ultimate-Multisite/ultimate-ai-connector-webllm/issues/3 --jq '{updated_at, marker: (.body | capture("last_refresh: (?<ts>[^\\n]+)").ts // "missing"), body_length: (.body|length)}'

Resolves #56


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.6 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 3m and 83,876 tokens on this as a headless worker.